### PR TITLE
OM - 402| Photo permission display

### DIFF
--- a/src/pages/membership/components/approveYouthProfile/ApproveYouthProfile.tsx
+++ b/src/pages/membership/components/approveYouthProfile/ApproveYouthProfile.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next';
 import Loading from '../../../../common/loading/Loading';
 import NotificationComponent from '../../../../common/notification/NotificationComponent';
 import convertBooleanToString from '../../helpers/convertBooleanToString';
-import convertDateToLocale from '../../helpers/convertDateToLocale';
 import getAddress from '../../helpers/getAddress';
 import PageLayout from '../../../../common/layout/PageLayout';
 import ConfirmApprovingYouthProfile from '../confirmApprovingYouthProfile/ConfirmApprovingYouthProfile';
@@ -93,9 +92,7 @@ function ApproveYouthProfile(props: Props) {
               phone:
                 data?.youthProfileByApprovalToken?.profile?.primaryPhone
                   ?.phone || '',
-              birthDate: convertDateToLocale(
-                data?.youthProfileByApprovalToken?.birthDate
-              ),
+              birthDate: data?.youthProfileByApprovalToken?.birthDate,
               schoolName: data?.youthProfileByApprovalToken?.schoolName || '',
               schoolClass: data?.youthProfileByApprovalToken?.schoolClass || '',
               approverFirstName:

--- a/src/pages/membership/components/approveYouthProfileForm/ApproveYouthProfileForm.tsx
+++ b/src/pages/membership/components/approveYouthProfileForm/ApproveYouthProfileForm.tsx
@@ -6,6 +6,7 @@ import { TextInput } from 'hds-react';
 import * as Yup from 'yup';
 import { differenceInYears } from 'date-fns';
 
+import convertDateToLocale from '../../helpers/convertDateToLocale';
 import ageConstants from '../../constants/ageConstants';
 import styles from './ApproveYouthProfileForm.module.css';
 import LabeledValue from '../../../../common/labeledValue/LabeledValue';
@@ -47,6 +48,7 @@ function ApproveYouthProfileForm(props: Props) {
   const { t } = useTranslation();
 
   const age = differenceInYears(new Date(), new Date(props.profile.birthDate));
+  const birthDate = convertDateToLocale(props.profile.birthDate);
 
   return (
     <Formik
@@ -87,10 +89,7 @@ function ApproveYouthProfileForm(props: Props) {
               label={t('approval.phone')}
               value={props.values.phone}
             />
-            <LabeledValue
-              label={t('approval.birthDate')}
-              value={props.values.birthDate}
-            />
+            <LabeledValue label={t('approval.birthDate')} value={birthDate} />
           </div>
           <h3>{t('approval.addInfo')}</h3>
           <div className={styles.formData}>


### PR DESCRIPTION
Because `birthDate` field was converted to locale format (dd.mm.yyyy) in `ApproveYouthProfile` component, it was in wrong format for `differenceInYears` method which would result it returning `NaN`. BirthDate is now passed down in right format (yyyy-mm-dd) to `ApproveYouthProfileForm`.

This component among many others would benefit from unit testing.