### PR TITLE
Changed query that is re-fetched on renew.

### DIFF
--- a/src/pages/membership/components/membershipInformation/MembershipInformation.tsx
+++ b/src/pages/membership/components/membershipInformation/MembershipInformation.tsx
@@ -38,7 +38,7 @@ function MembershipInformation(props: Props) {
   const [renewMembership] = useMutation<
     RenewMyYouthProfileData,
     RenewMyYouthProfileVariables
-  >(RENEW_MEMBERSHIP, { refetchQueries: ['HasYouthProfile'] });
+  >(RENEW_MEMBERSHIP, { refetchQueries: ['MembershipInformation'] });
 
   const validUntil = convertDateToLocale(data?.youthProfile?.expiration);
 


### PR DESCRIPTION
After creating new mutation for fetching data in MembershipInformation component, I forgot to change query that is re-fetched if mutation is successful.