### PR TITLE
OM-620 | Fix backend URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 REACT_APP_OIDC_AUTHORITY="https://tunnistamo.test.kuva.hel.ninja/"
 REACT_APP_OIDC_CLIENT_ID="https://api.hel.fi/auth/jassari"
-REACT_APP_PROFILE_GRAPHQL="https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+REACT_APP_PROFILE_GRAPHQL="https://profiili-api.test.kuva.hel.ninja/graphql/"

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,1 @@
-REACT_APP_PROFILE_GRAPHQL="https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+REACT_APP_PROFILE_GRAPHQL="https://profiili-api.test.kuva.hel.ninja/graphql/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ build-review:
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
     DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://tunnistamo.test.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
   only:
     refs:
       - external_pull_requests
@@ -22,7 +22,7 @@ build-staging:
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
     DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://tunnistamo.test.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
   only:
     refs:
       - develop
@@ -31,8 +31,8 @@ build-production:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://tunnistamo.test.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://profiili-api.prod.kuva.hel.ninja/graphql/"
   only:
     refs:
       - master

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "react-scripts test",
     "ci": "CI=true yarn test --coverage",
     "lint": "eslint --ext js,ts,tsx src",
-    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://helsinkiprofile.test.kuva.hel.ninja/graphql/ --useReadOnlyTypes --addTypename"
+    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profiili-api.test.kuva.hel.ninja/graphql/ --useReadOnlyTypes --addTypename"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/pages/membership/components/membershipInformation/MembershipInformation.tsx
+++ b/src/pages/membership/components/membershipInformation/MembershipInformation.tsx
@@ -74,7 +74,7 @@ function MembershipInformation(props: Props) {
           </p>
           <QRCode
             size={175}
-            value="https://helsinkiprofile.test.kuva.hel.ninja/admin/"
+            value="https://profiili-api.test.kuva.hel.ninja/admin/"
           />
            
           {data?.youthProfile?.renewable && (


### PR DESCRIPTION
The URL for the profile backend was changed recently to profiili-api.* so I
changed it to the appropriate places in the UI's configuration. I also
changed the production config, since that was anyway pointing to the test
environment which is wrong.