### PR TITLE
OM 745 | Youth can remove approver information

### DIFF
--- a/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
+++ b/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
@@ -41,7 +41,14 @@ const schema = Yup.object().shape({
   approverFirstName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
-    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
+    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => return isConsentRequired(birthDate, schema)
+    
+    const isConsentRequired = (birthDate:string, schema: Yup.StringSchema) => {
+      const userAge = differenceInYears(new Date(), new Date(value));
+      return userAge < ageConstants.ADULT
+        ? schema.required('validation.required')
+        : schema;
+    }
       const userAge = differenceInYears(new Date(), new Date(value));
       return userAge < ageConstants.ADULT
         ? schema.required('validation.required')

--- a/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
+++ b/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
@@ -12,6 +12,13 @@ import { Language, YouthLanguage } from '../../../../graphql/generatedTypes';
 import styles from './YouthProfileForm.module.css';
 import Button from '../../../../common/button/Button';
 
+const isConsentRequired = (birthDate: string, schema: Yup.StringSchema) => {
+  const userAge = differenceInYears(new Date(), new Date(birthDate));
+  return userAge < ageConstants.ADULT
+    ? schema.required('validation.required')
+    : schema;
+};
+
 const schema = Yup.object().shape({
   firstName: Yup.string()
     .min(2, 'validation.tooShort')
@@ -41,44 +48,25 @@ const schema = Yup.object().shape({
   approverFirstName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
-    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => return isConsentRequired(birthDate, schema)
-    
-    const isConsentRequired = (birthDate:string, schema: Yup.StringSchema) => {
-      const userAge = differenceInYears(new Date(), new Date(value));
-      return userAge < ageConstants.ADULT
-        ? schema.required('validation.required')
-        : schema;
-    }
-      const userAge = differenceInYears(new Date(), new Date(value));
-      return userAge < ageConstants.ADULT
-        ? schema.required('validation.required')
-        : schema;
-    }),
+    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
+      isConsentRequired(birthDate, schema)
+    ),
   approverLastName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
-    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
-      const userAge = differenceInYears(new Date(), new Date(value));
-      return userAge < ageConstants.ADULT
-        ? schema.required('validation.required')
-        : schema;
-    }),
+    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
+      isConsentRequired(birthDate, schema)
+    ),
   approverPhone: Yup.string()
     .min(6, 'validation.phoneMin')
-    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
-      const userAge = differenceInYears(new Date(), new Date(value));
-      return userAge < ageConstants.ADULT
-        ? schema.required('validation.required')
-        : schema;
-    }),
+    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
+      isConsentRequired(birthDate, schema)
+    ),
   approverEmail: Yup.string()
     .email('validation.email')
-    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
-      const userAge = differenceInYears(new Date(), new Date(value));
-      return userAge < ageConstants.ADULT
-        ? schema.required('validation.required')
-        : schema;
-    }),
+    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
+      isConsentRequired(birthDate, schema)
+    ),
   photoUsageApproved: Yup.string().required('validation.required'),
   terms: Yup.boolean().oneOf([true], 'validation.required'),
 });

--- a/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
+++ b/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
@@ -8,13 +8,9 @@ import * as Yup from 'yup';
 
 import Select from '../../../../common/select/Select';
 import ageConstants from '../../constants/ageConstants';
-import getCookie from '../../helpers/getCookie';
 import { Language, YouthLanguage } from '../../../../graphql/generatedTypes';
 import styles from './YouthProfileForm.module.css';
 import Button from '../../../../common/button/Button';
-
-const BD = getCookie('birthDate');
-const AGE = differenceInYears(new Date(), new Date(BD));
 
 const schema = Yup.object().shape({
   firstName: Yup.string()
@@ -45,30 +41,34 @@ const schema = Yup.object().shape({
   approverFirstName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
-    .when([], (schema: Yup.StringSchema) => {
-      return AGE < ageConstants.ADULT
+    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
+      const userAge = differenceInYears(new Date(), new Date(value));
+      return userAge < ageConstants.ADULT
         ? schema.required('validation.required')
         : schema;
     }),
   approverLastName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
-    .when([], (schema: Yup.StringSchema) => {
-      return AGE < ageConstants.ADULT
+    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
+      const userAge = differenceInYears(new Date(), new Date(value));
+      return userAge < ageConstants.ADULT
         ? schema.required('validation.required')
         : schema;
     }),
   approverPhone: Yup.string()
     .min(6, 'validation.phoneMin')
-    .when([], (schema: Yup.StringSchema) => {
-      return AGE < ageConstants.ADULT
+    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
+      const userAge = differenceInYears(new Date(), new Date(value));
+      return userAge < ageConstants.ADULT
         ? schema.required('validation.required')
         : schema;
     }),
   approverEmail: Yup.string()
     .email('validation.email')
-    .when([], (schema: Yup.StringSchema) => {
-      return AGE < ageConstants.ADULT
+    .when(['birthDate'], (value: string, schema: Yup.StringSchema) => {
+      const userAge = differenceInYears(new Date(), new Date(value));
+      return userAge < ageConstants.ADULT
         ? schema.required('validation.required')
         : schema;
     }),
@@ -107,13 +107,18 @@ function YouthProfileForm(componentProps: Props) {
   const { t } = useTranslation();
   const languages = ['FINNISH', 'SWEDISH', 'ENGLISH'];
 
+  const userAge = differenceInYears(
+    new Date(),
+    new Date(componentProps.profile.birthDate)
+  );
+
   // For now when using .when() in validation we can't use
   // schema.describe().fields[name].tests to determine if field is required or not.
   // Validation rules returned from .when() won't be added there.
   // For this reason determining asterisk usage must
   // be done with this function
   const approverLabelText = (name: string) => {
-    if (AGE < ageConstants.ADULT) return t(`registration.${name}`) + ' *';
+    if (userAge < ageConstants.ADULT) return t(`registration.${name}`) + ' *';
     return t(`registration.${name}`);
   };
 
@@ -310,7 +315,7 @@ function YouthProfileForm(componentProps: Props) {
             </ul>
             <div
               className={
-                AGE < ageConstants.PHOTO_PERMISSION_MIN
+                userAge < ageConstants.PHOTO_PERMISSION_MIN
                   ? styles.hidePhotoUsageApproved
                   : ''
               }
@@ -349,8 +354,10 @@ function YouthProfileForm(componentProps: Props) {
               </div>
             </div>
             <h3>{t('registration.approver')}</h3>
-            {AGE < ageConstants.ADULT && (
-              <p>{t('registration.approverInfoText')}</p>
+            {userAge < ageConstants.ADULT && (
+              <p data-testid="approverInfoText">
+                {t('registration.approverInfoText')}
+              </p>
             )}
             <div className={styles.formRow}>
               <Field
@@ -413,7 +420,7 @@ function YouthProfileForm(componentProps: Props) {
             {!componentProps.isEditing && (
               <React.Fragment>
                 <h3>{t('registration.confirmSend')}</h3>
-                {AGE < ageConstants.ADULT && (
+                {userAge < ageConstants.ADULT && (
                   <p>{t('registration.processInfoText')}</p>
                 )}
                 <ul className={styles.terms}>

--- a/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
+++ b/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
@@ -75,7 +75,7 @@ test('Profile is used for profile editing', async () => {
 });
 
 describe('Form fields & texts based on user age', () => {
-  test('user age is > 13 < 15', () => {
+  test('user age is >= 13 < 15', () => {
     // Create birthDate that fits test criteria
     const userAge = format(subYears(new Date(), 14), 'yyyy-MM-dd');
     const wrapper = getWrapper(getPrefilledProfile({ birthDate: userAge }));
@@ -86,7 +86,7 @@ describe('Form fields & texts based on user age', () => {
     expect(photoPermission.length).toEqual(1);
     expect(approverInfoText.length).toEqual(1);
   });
-  test('user age is > 15 < 18', () => {
+  test('user age is >= 15 < 18', () => {
     // Create birthDate that fits test criteria
     const userAge = format(subYears(new Date(), 16), 'yyyy-MM-dd');
     const wrapper = getWrapper(getPrefilledProfile({ birthDate: userAge }));

--- a/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
+++ b/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
@@ -1,29 +1,33 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router';
+import { subYears, format } from 'date-fns';
 
 import YouthProfileForm, { FormValues } from '../YouthProfileForm';
 import { Language, YouthLanguage } from '../../../../../graphql/generatedTypes';
 import { updateWrapper } from '../../../../../common/test/testUtils';
 
-const prefilledProfile: FormValues = {
-  firstName: 'Test',
-  lastName: 'Person',
-  birthDate: '2000-1-1',
-  email: 'test@test.fi',
-  phone: '0501234567',
-  address: 'TestAddress',
-  city: 'Helsinki',
-  postalCode: '12345',
-  profileLanguage: Language.FINNISH,
-  languageAtHome: YouthLanguage.FINNISH,
-  schoolName: 'School',
-  schoolClass: '',
-  photoUsageApproved: 'false',
-  approverEmail: 'test@test.fi',
-  approverLastName: 'TestApprover',
-  approverFirstName: 'TestFirstName',
-  approverPhone: '0501234567',
+const getPrefilledProfile = (values?: Partial<FormValues>) => {
+  return {
+    firstName: 'Test',
+    lastName: 'Person',
+    birthDate: '2000-1-1',
+    email: 'test@test.fi',
+    phone: '0501234567',
+    address: 'TestAddress',
+    city: 'Helsinki',
+    postalCode: '12345',
+    profileLanguage: Language.FINNISH,
+    languageAtHome: YouthLanguage.FINNISH,
+    schoolName: 'School',
+    schoolClass: '',
+    photoUsageApproved: 'false',
+    approverEmail: 'test@test.fi',
+    approverLastName: 'TestApprover',
+    approverFirstName: 'TestFirstName',
+    approverPhone: '0501234567',
+    ...values,
+  };
 };
 
 const getWrapper = (profile: FormValues, isEditing?: boolean) => {
@@ -40,7 +44,7 @@ const getWrapper = (profile: FormValues, isEditing?: boolean) => {
 };
 
 test('Form is used for profile creation with pre-filled data ', async () => {
-  const wrapper = getWrapper(prefilledProfile);
+  const wrapper = getWrapper(getPrefilledProfile());
   await updateWrapper(wrapper);
 
   const firstName = wrapper.find('input[id="firstName"]');
@@ -57,7 +61,7 @@ test('Form is used for profile creation with pre-filled data ', async () => {
 });
 
 test('Profile is used for profile editing', async () => {
-  const wrapper = getWrapper(prefilledProfile, true);
+  const wrapper = getWrapper(getPrefilledProfile(), true);
 
   await updateWrapper(wrapper);
 
@@ -68,4 +72,38 @@ test('Profile is used for profile editing', async () => {
   expect(submitButton.text()).toEqual('Tallenna tiedot');
   expect(buttonRow.children().length).toEqual(2);
   expect(terms.length).toEqual(0);
+});
+
+describe('Form fields & texts based on user age', () => {
+  test('user age is > 13 < 15', () => {
+    // Create birthDate that fits test criteria
+    const userAge = format(subYears(new Date(), 14), 'yyyy-MM-dd');
+    const wrapper = getWrapper(getPrefilledProfile({ birthDate: userAge }));
+    const photoPermission = wrapper.find('.hidePhotoUsageApproved');
+    const approverInfoText = wrapper.find('p[data-testid="approverInfoText"]');
+
+    // Photo permission is not shown
+    expect(photoPermission.length).toEqual(1);
+    expect(approverInfoText.length).toEqual(1);
+  });
+  test('user age is > 15 < 18', () => {
+    // Create birthDate that fits test criteria
+    const userAge = format(subYears(new Date(), 16), 'yyyy-MM-dd');
+    const wrapper = getWrapper(getPrefilledProfile({ birthDate: userAge }));
+    const photoPermission = wrapper.find('.hidePhotoUsageApproved');
+    const approverInfoText = wrapper.find('p[data-testid="approverInfoText"]');
+
+    // Photo permission is shown
+    expect(photoPermission.length).toEqual(0);
+    expect(approverInfoText.length).toEqual(1);
+  });
+  test('user is over 18', () => {
+    // Create birthDate that fits test criteria
+    const userAge = format(subYears(new Date(), 19), 'yyyy-MM-dd');
+    const wrapper = getWrapper(getPrefilledProfile({ birthDate: userAge }));
+    const approverInfoText = wrapper.find('p[data-testid="approverInfoText"]');
+
+    // Helper texts about guardian approval are hidden
+    expect(approverInfoText.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
Fixed issue where under 18 years old could change / remove approver information while editing profile. Now that age is determined by value coming from props, I added few tests based on user's age.