### PR TITLE
OM-542 | Add update-translations script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 Generate static types for GraphQL queries by using the schema from the backend server.
 
+### `yarn update-translations`
+
+Creates new translation message files based on current version of translation source and overwrites existing files with them.
+
 ## Setting up development environment locally with docker
 
 ### Set tunnistamo hostname

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "graphql.macro": "^1.4.2",
     "hds-core": "^0.4.1",
     "hds-react": "^0.5.4",
-    "helsinki-utils": "https://github.com/City-of-Helsinki/helsinki-utils-js.git#0.1.0",
     "i18next": "^17.3.0",
     "i18next-browser-languagedetector": "^4.0.1",
     "oidc-client": "^1.10.1",
@@ -81,6 +80,7 @@
     "cypress": "^4.3.0",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-prettier": "^3.1.1",
+    "helsinki-utils": "https://github.com/City-of-Helsinki/helsinki-utils-js.git#0.1.0",
     "jest-canvas-mock": "^2.2.0",
     "jest-fetch-mock": "^2.1.2",
     "prettier": "^1.19.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "graphql.macro": "^1.4.2",
     "hds-core": "^0.4.1",
     "hds-react": "^0.5.4",
+    "helsinki-utils": "https://github.com/City-of-Helsinki/helsinki-utils-js.git#0.1.0",
     "i18next": "^17.3.0",
     "i18next-browser-languagedetector": "^4.0.1",
     "oidc-client": "^1.10.1",
@@ -56,7 +57,8 @@
     "ci": "CI=true yarn test --coverage",
     "lint": "eslint --ext js,ts,tsx src",
     "cypress:open": "cypress open",
-    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profiili-api.test.kuva.hel.ninja/graphql/ --useReadOnlyTypes --addTypename"
+    "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://profiili-api.test.kuva.hel.ninja/graphql/ --useReadOnlyTypes --addTypename",
+    "update-translations": "fetch-translations 1kvN0olQHdTqsI25yxJucL2Cqq6PXaPjHAkXpKJPjxjU -l fi,en,sv -o ./src/i18n"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4343,6 +4343,11 @@ commander@^2.19.0, commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -5037,6 +5042,11 @@ detect-port-alt@1.1.6:
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1:
   version "4.0.1"
@@ -6597,6 +6607,14 @@ header-case@^1.0.0:
     no-case "^2.2.0"
     upper-case "^1.1.3"
 
+"helsinki-utils@https://github.com/City-of-Helsinki/helsinki-utils-js.git#0.1.0":
+  version "0.1.0"
+  resolved "https://github.com/City-of-Helsinki/helsinki-utils-js.git#7e3fe9d6c33929428fbde49d4e5112cbd3daf7b1"
+  dependencies:
+    commander "^5.1.0"
+    i18next-json-csv-converter "^0.2.0"
+    node-fetch "^2.6.0"
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -6816,6 +6834,13 @@ i18next-browser-languagedetector@^4.0.1:
   integrity sha512-RxSoX6mB8cab0CTIQ+klCS764vYRj+Jk621cnFVsINvcdlb/cdi3vQFyrPwmnowB7ReUadjHovgZX+RPIzHVQQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
+
+i18next-json-csv-converter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/i18next-json-csv-converter/-/i18next-json-csv-converter-0.2.0.tgz#b9d4056c02bf9ad83fd9f540080018f952ec6f98"
+  integrity sha512-TDrI3LplYKPAffl9Rha/cmvqdz46DeSaxqu5AZYyb30Ow3u3TRFgPakFjfd6KkCztXeNcqzj08zyTNgvyUIFbA==
+  dependencies:
+    diff "^3.5.0"
 
 i18next@^17.3.0:
   version "17.3.1"
@@ -8735,7 +8760,7 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0:
+node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
Adds `yarn update-translations` script from [helsinki-utils-js](https://github.com/City-of-Helsinki/helsinki-utils-js). It creates new translation message files based on the current version of translation source and overwrites existing files with them.

I haven't fetched the latest translations in this PR--should I?