### PR TITLE
YM-227 | PhotoUsageApproved is now passed to backend.

### DIFF
--- a/src/pages/membership/components/editYouthProfile/EditYouthProfile.tsx
+++ b/src/pages/membership/components/editYouthProfile/EditYouthProfile.tsx
@@ -5,10 +5,8 @@ import { useHistory } from 'react-router';
 import * as Sentry from '@sentry/browser';
 
 import {
-  AddressType,
   Language,
   MembershipDetails as MembershipDetailsData,
-  PhoneType,
   UpdateMyProfile as UpdateMyProfileData,
   UpdateMyProfileVariables,
   YouthLanguage,
@@ -18,6 +16,7 @@ import YouthProfileForm, {
 } from '../youthProfileForm/YouthProfileForm';
 import styles from './EditYouthProfile.module.css';
 import NotificationComponent from '../../../../common/notification/NotificationComponent';
+import { getEditMutationVariables } from '../../helpers/updateProfileMutationVariables';
 
 const MEMBERSHIP_DETAILS = loader('../../graphql/MembershipDetails.graphql');
 const UPDATE_PROFILE = loader('../../graphql/UpdateMyProfile.graphql');
@@ -39,49 +38,10 @@ function EditYouthProfile(props: Props) {
   const youthProfile = data?.youthProfile;
 
   const handleOnValues = (formValues: FormValues) => {
-    const variables: UpdateMyProfileVariables = {
-      input: {
-        profile: {
-          firstName: formValues.firstName,
-          lastName: formValues.lastName,
-          language: formValues.profileLanguage,
-          updateAddresses: [
-            youthProfile?.profile?.primaryAddress?.id
-              ? {
-                  address: formValues.address,
-                  postalCode: formValues.postalCode,
-                  city: formValues.city,
-                  addressType: AddressType.OTHER,
-                  primary: true,
-                  countryCode: formValues.countryCode,
-                  id: youthProfile?.profile?.primaryAddress?.id,
-                }
-              : null,
-          ],
-          updatePhones: [
-            youthProfile?.profile.primaryPhone?.id
-              ? {
-                  phone: formValues.phone,
-                  phoneType: PhoneType.OTHER,
-                  primary: true,
-                  id: youthProfile.profile.primaryPhone.id,
-                }
-              : null,
-          ],
-          youthProfile: {
-            birthDate: youthProfile?.birthDate,
-            schoolName: formValues.schoolName,
-            schoolClass: formValues.schoolClass,
-            approverFirstName: formValues.approverFirstName,
-            approverLastName: formValues.approverLastName,
-            approverPhone: formValues.approverPhone,
-            approverEmail: formValues.approverEmail,
-            languageAtHome: formValues.languageAtHome,
-            photoUsageApproved: formValues.photoUsageApproved === 'true',
-          },
-        },
-      },
-    };
+    const variables: UpdateMyProfileVariables = getEditMutationVariables(
+      formValues,
+      data
+    );
 
     updateProfile({ variables })
       .then(() => {

--- a/src/pages/membership/components/editYouthProfile/EditYouthProfile.tsx
+++ b/src/pages/membership/components/editYouthProfile/EditYouthProfile.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
 import { useHistory } from 'react-router';
+import * as Sentry from '@sentry/browser';
 
 import {
   AddressType,
@@ -76,6 +77,7 @@ function EditYouthProfile(props: Props) {
             approverPhone: formValues.approverPhone,
             approverEmail: formValues.approverEmail,
             languageAtHome: formValues.languageAtHome,
+            photoUsageApproved: formValues.photoUsageApproved === 'true',
           },
         },
       },
@@ -85,7 +87,10 @@ function EditYouthProfile(props: Props) {
       .then(() => {
         history.push('/membership-details');
       })
-      .catch((error: Error) => setShowNotification(true));
+      .catch((error: Error) => {
+        Sentry.captureException(error);
+        setShowNotification(true);
+      });
   };
 
   return (
@@ -113,7 +118,8 @@ function EditYouthProfile(props: Props) {
               youthProfile?.profile?.language || Language.FINNISH,
             languageAtHome:
               youthProfile?.languageAtHome || YouthLanguage.FINNISH,
-            photoUsageApproved: 'false',
+            photoUsageApproved:
+              youthProfile?.photoUsageApproved?.toString() || 'false',
           }}
           isEditing={true}
           isSubmitting={saveLoading}

--- a/src/pages/membership/helpers/__tests__/updateProfileMutationVariables.test.ts
+++ b/src/pages/membership/helpers/__tests__/updateProfileMutationVariables.test.ts
@@ -1,0 +1,114 @@
+import { FormValues } from '../../components/youthProfileForm/YouthProfileForm';
+import {
+  AddressType,
+  Language,
+  MembershipDetails,
+  PhoneType,
+  YouthLanguage,
+} from '../../../../graphql/generatedTypes';
+import { getEditMutationVariables } from '../updateProfileMutationVariables';
+
+const formValues: FormValues = {
+  firstName: 'Tina',
+  lastName: 'Testaaja',
+  email: 'tina@testaaja.fi',
+  phone: '0501234567',
+  city: 'Helsinki',
+  postalCode: '00100',
+  address: 'Testaddress 123',
+  photoUsageApproved: 'false',
+  birthDate: '2000-01-01',
+  languageAtHome: YouthLanguage.FINNISH,
+  approverPhone: '0501234567',
+  approverEmail: 'gee@guardian.com',
+  approverLastName: 'Guardian',
+  approverFirstName: 'Gee',
+  schoolClass: '1S',
+  schoolName: 'Smooth School',
+  countryCode: 'FI',
+  profileLanguage: Language.FINNISH,
+};
+
+const profileData: MembershipDetails = {
+  youthProfile: {
+    profile: {
+      firstName: 'Teemu',
+      lastName: 'Testaaja',
+      language: Language.FINNISH,
+      primaryAddress: {
+        __typename: 'AddressNode',
+        address: 'Testikatu 123',
+        city: 'Helsinki',
+        countryCode: 'FI',
+        id: '123',
+        postalCode: '00100',
+      },
+      primaryEmail: {
+        email: 'teemu.testaaja@test.fi',
+        __typename: 'EmailNode',
+        id: '123',
+      },
+      primaryPhone: {
+        id: '123',
+        __typename: 'PhoneNode',
+        phone: '0501234567',
+      },
+      __typename: 'ProfileNode',
+    },
+    membershipNumber: '12345',
+    birthDate: '2000-01-01',
+    languageAtHome: YouthLanguage.FINNISH,
+    approverPhone: '0501234567',
+    approverEmail: 'gee@guardian.com',
+    approverLastName: 'Guardian',
+    approverFirstName: 'Gee',
+    schoolClass: '1S',
+    schoolName: 'Smooth School',
+    photoUsageApproved: false,
+    __typename: 'YouthProfileType',
+  },
+};
+
+test('test object is correct and all fields are present', () => {
+  const variables = getEditMutationVariables(formValues, profileData);
+
+  const expectedResult = {
+    input: {
+      profile: {
+        firstName: 'Tina',
+        lastName: 'Testaaja',
+        language: Language.FINNISH,
+        updateAddresses: [
+          {
+            city: 'Helsinki',
+            postalCode: '00100',
+            address: 'Testaddress 123',
+            id: '123',
+            countryCode: 'FI',
+            addressType: AddressType.OTHER,
+          },
+        ],
+        updatePhones: [
+          {
+            phone: '0501234567',
+            id: '123',
+            phoneType: PhoneType.OTHER,
+          },
+        ],
+        youthProfile: {
+          photoUsageApproved: false,
+          birthDate: '2000-01-01',
+          languageAtHome: YouthLanguage.FINNISH,
+          approverPhone: '0501234567',
+          approverEmail: 'gee@guardian.com',
+          approverLastName: 'Guardian',
+          approverFirstName: 'Gee',
+          schoolClass: '1S',
+          schoolName: 'Smooth School',
+        },
+      },
+    },
+  };
+
+  expect(variables).toEqual(expectedResult);
+});

--- a/src/pages/membership/helpers/updateProfileMutationVariables.ts
+++ b/src/pages/membership/helpers/updateProfileMutationVariables.ts
@@ -1,0 +1,46 @@
+import { FormValues } from '../components/youthProfileForm/YouthProfileForm';
+import {
+  AddressType,
+  MembershipDetails,
+  PhoneType,
+} from '../../../graphql/generatedTypes';
+import { getYouthProfile } from './createProfileMutationVariables';
+
+const getEditMutationVariables = (
+  formValues: FormValues,
+  profile?: MembershipDetails
+) => {
+  return {
+    input: {
+      profile: {
+        firstName: formValues.firstName,
+        lastName: formValues.lastName,
+        language: formValues.profileLanguage,
+        updateAddresses: [
+          profile?.youthProfile?.profile?.primaryAddress?.id
+            ? {
+                address: formValues.address,
+                city: formValues.city,
+                postalCode: formValues.postalCode,
+                countryCode: formValues.countryCode,
+                id: profile.youthProfile.profile.primaryAddress.id,
+                addressType: AddressType.OTHER,
+              }
+            : null,
+        ],
+        updatePhones: [
+          profile?.youthProfile?.profile?.primaryPhone?.id
+            ? {
+                phone: formValues.phone,
+                phoneType: PhoneType.OTHER,
+                id: profile.youthProfile.profile.primaryPhone.id,
+              }
+            : null,
+        ],
+        youthProfile: getYouthProfile(formValues),
+      },
+    },
+  };
+};
+
+export { getEditMutationVariables };


### PR DESCRIPTION
- When editing profile, `photoUsageApproved` field is sent to backend.
- When adding missing field I noticed update mutation was missing Sentry capturing so I added that as well.