### PR TITLE
YM-228 | Tests for ConfirmApprovingYouthProfile

### DIFF
--- a/src/pages/membership/components/confirmApprovingYouthProfile/__tests__/ConfirmApprovingYouthProfile.test.tsx
+++ b/src/pages/membership/components/confirmApprovingYouthProfile/__tests__/ConfirmApprovingYouthProfile.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import ConfirmApprovingYouthProfile from '../ConfirmApprovingYouthProfile';
+
+test('matches snapshot', () => {
+  const wrapper = shallow(<ConfirmApprovingYouthProfile />);
+  expect(toJson(wrapper)).toMatchSnapshot();
+});

--- a/src/pages/membership/components/confirmApprovingYouthProfile/__tests__/__snapshots__/ConfirmApprovingYouthProfile.test.tsx.snap
+++ b/src/pages/membership/components/confirmApprovingYouthProfile/__tests__/__snapshots__/ConfirmApprovingYouthProfile.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches snapshot 1`] = `
+<div
+  className="container"
+>
+  <h1>
+    Jässärihakemus hyväksytty!
+  </h1>
+  <p>
+    Kiitos kun varmistit nuorisopalveluiden jäsenyyden.
+  </p>
+</div>
+`;


### PR DESCRIPTION
Added test for `ConfirmApprovingYouthProfile` component. The component is really simple so simple snapshot test should be enough.