### PR TITLE
OM-849 | Improve postalCode validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "i18next-browser-languagedetector": "^4.0.1",
     "lodash": "^4.17.15",
     "oidc-client": "^1.10.1",
+    "postcode-validator": "^3.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-helmet-async": "^1.0.5",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -61,7 +61,7 @@
     "buttonText": "Get membership",
     "findNearestService": "Find the nearest youth centre on the service map",
     "helpText": "Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
-    "helpTextUnderAge": "Unfortunately, you need to be at least 13 years old to get a digital Jässäri. This is because of the user terms and conditions of the Helsinki Profile. You can get a paper application form from the Youth Centres of the City. ",
+    "helpTextUnderAge": "Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here. ",
     "linkForMembersText": "Do you have membership? Log in",
     "registrationForm": "http://jassari.munstadi.fi/files/2019/06/Jasenkorttikaavake_2019_englanti.pdf",
     "registrationFormText": "Download application",
@@ -174,6 +174,7 @@
   },
   "validation": {
     "email": "Invalid email",
+    "invalidValue": "Invalid value",
     "phoneMin": "Min length six characters",
     "required": "Required",
     "tooLong": "Too long",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -61,7 +61,7 @@
     "buttonText": "Hanki jäsenyys",
     "findNearestService": "Löydä lähin nuorisotila palvelukartalta",
     "helpText": "Jässärillä pääset mukaan nuorisopalveluiden toimintaan. Jäsenyys takaa sinulle kivaa tekemistä, voit hengailla nuorisotaloilla, osallistua harrastusryhmiin, kursseille ja leireille, hakea projektiavustusta tai vaikka tuottaa oman tapahtuman! Nuorisotaloilla toimintaa ohjaavat koulutetut nuoriso-ohjaajat.",
-    "helpTextUnderAge": "Valitettavasti Jässärin hankkiminen digitaalisesti edellyttää vähintään 13 vuoden iän johtuen Helsinki-profiilin käyttöehdoista. Saat paperisen jässärihakemuksen kaupungin nuorisotiloilta. ",
+    "helpTextUnderAge": "Valitettavasti Jässärin hankkiminen digitaalisesti edellyttää vähintään 13 vuoden iän. Voit ladata jässärihakemuksen tästä.",
     "linkForMembersText": "Oletko jo jäsen? Kirjaudu sisään",
     "registrationForm": "http://jassari.munstadi.fi/files/2019/06/Jasenkorttikaavake_2019_suomi.pdf",
     "registrationFormText": "Lataa hakemus",
@@ -174,6 +174,7 @@
   },
   "validation": {
     "email": "Virheellinen sähköpostiosoite",
+    "invalidValue": "Virheellinen arvo",
     "phoneMin": "Vähimmäispituus kuusi merkkiä",
     "required": "Vaadittu",
     "tooLong": "Liian pitkä",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -61,10 +61,10 @@
     "buttonText": "Få medlemskap",
     "findNearestService": "Hitta närmaste ungdomsanläggning på servicekartan",
     "helpText": "Jässäri är ditt medlemskort till ungdomsgårdarna. Medlemskapet garanterar trevliga aktiviteter: häng på ungdomsgårdarna, delta i hobbygrupper, ansök om projektunderstöd eller producera ett eget evenemang! Verksamheten leds av utbildade ungdomsledare.",
-    "helpTextUnderAge": "För att skaffa Jässäri digitalt måste du ha fyllt 13 år på grund av användningsvillkoren i Helsingfors profil. Om du är yngre kan du få en ansökningsblankett för Jässäri från stadens ungdomsgårdar. Fyll i blanketten tillsammans med din vårdnadshavare och returnera den till ungdomsgården, så får du ett eget medlemskort.",
+    "helpTextUnderAge": "För att skaffa Jässäri digitalt måste du ha fyllt 13 år. Om du är yngre kan du ladda ner en ansökningsblankett för Jässäri här. Fyll i blanketten tillsammans med din vårdnadshavare och returnera den till ungdomsgården, så får du ett eget medlemskort.",
     "linkForMembersText": "Har du medlemskap? Logga in",
     "registrationForm": "http://jassari.munstadi.fi/files/2019/06/Jasenkorttikaavake_2019_ruotsi.pdf",
-    "registrationFormText": "Ladda new applikationen",
+    "registrationFormText": "Ladda ner ansökningsblankett ",
     "return": "Gå tillbaka",
     "title": "Skaffa Jässäri!"
   },
@@ -173,6 +173,7 @@
   },
   "validation": {
     "email": "Ogiltig e-postadress",
+    "invalidValue": "Ogiltigt värde",
     "phoneMin": "Minst sex tecken",
     "required": "Nödvändig",
     "tooLong": "För lång",

--- a/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
+++ b/src/pages/membership/components/youthProfileForm/YouthProfileForm.tsx
@@ -42,14 +42,14 @@ const schema = Yup.object().shape({
     .required('validation.required'),
   postalCode: Yup.mixed()
     .required('validation.required')
-    .test('isValid', 'Invalid postal code', function() {
+    .test('isValidPostalCode', 'validation.invalidValue', function() {
       if (postcodeValidatorExistsForCountry(this.parent.countryCode)) {
         return postcodeValidator(
           this.parent.postalCode,
           this.parent.countryCode
         );
       }
-      return this.parent?.postalCode?.length < 10;
+      return this.parent?.postalCode?.length < 32;
     }),
   city: Yup.string()
     .min(2, 'validation.tooShort')
@@ -186,6 +186,18 @@ function YouthProfileForm(componentProps: Props) {
             </div>
             <div className={styles.formRow}>
               <Field
+                as={Select}
+                setFieldValue={props.setFieldValue}
+                id="countryCode"
+                name="countryCode"
+                type="select"
+                options={countryOptions}
+                className={styles.formInput}
+                labelText={t('registration.country')}
+              />
+            </div>
+            <div className={styles.formRow}>
+              <Field
                 className={styles.formInput}
                 as={TextInput}
                 id="address"
@@ -229,18 +241,6 @@ function YouthProfileForm(componentProps: Props) {
                   labelText={t('registration.city') + ' *'}
                 />
               </div>
-            </div>
-            <div className={styles.formRow}>
-              <Field
-                as={Select}
-                setFieldValue={props.setFieldValue}
-                id="countryCode"
-                name="countryCode"
-                type="select"
-                options={countryOptions}
-                className={styles.formInput}
-                labelText={t('registration.country')}
-              />
             </div>
             <div className={styles.formRow}>
               <Field

--- a/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
+++ b/src/pages/membership/components/youthProfileForm/__tests__/YouthProfileForm.test.tsx
@@ -115,3 +115,17 @@ describe('Form fields & texts based on user age', () => {
     );
   });
 });
+
+describe('postalCode inputMode changes based on selected country', () => {
+  test('inputMode is numeric when countryCode === "FI" ', () => {
+    const wrapper = getWrapper(getPrefilledProfile());
+    const postalCode = wrapper.find('input[name="postalCode"]');
+    expect(postalCode.props().inputMode).toEqual('numeric');
+  });
+
+  test('inputMode is text when countryCode !== "FI', () => {
+    const wrapper = getWrapper(getPrefilledProfile({ countryCode: 'SV' }));
+    const postalCode = wrapper.find('input[name="postalCode"]');
+    expect(postalCode.props().inputMode).toEqual('text');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9782,6 +9782,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+postcode-validator@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcode-validator/-/postcode-validator-3.1.0.tgz#12f9a99010e7f29802e113a061fdc97c2b0a8457"
+  integrity sha512-K2uylJ6WqzJIYyYwDbeLo3BC8iq1hsy5u6PuiOGXKDfFEdUWmd4UjVjjyrwGPlOPmLInpaHCm7J5IoJQYFKFsg==
+
 postcss-attribute-case-insensitive@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz#b2a721a0d279c2f9103a36331c88981526428cc7"


### PR DESCRIPTION
- Added `postcode-validator` for validation
- Moved country selection box to be before other address information.
- PostalCode inputMode changes based on current languageCode 
- Added tests for checking inputMode changes
- Because implementing tests with formik currently results to pile of errors, I will add tests testing validation later.
