### PR TITLE
YM-293 | Remove robot.txt disallow parameter

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow: /


### PR DESCRIPTION
Removed `Disallow` parameter from `robot.txt` file.