### PR TITLE
YM-302 | Hide number input spinners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Authentication info text position
+- Hide spinners from birth day input on Firefox
 
 ## [1.0.0-rc.3]

--- a/src/common/components/dateInput/DateInput.tsx
+++ b/src/common/components/dateInput/DateInput.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { TextInput } from 'hds-react';
 
 import DateInputGroup from './DateInputGroup';
 import DateInputLogic, { InputComponentProps } from './DateInputLogic';
 import DateInputRow from './DateInputRow';
+import InputWithoutSpinners from './InputWithoutSpinners';
 import styles from './dateInput.module.css';
 
 const DEFAULT_DATE_INPUT_DATE_ID = 'ym-date-input-date-id';
@@ -18,7 +18,12 @@ const DEFAULT_DAY_OF_MONTH_INPUT = ({
   ...rest
 }: InputComponentProps) => (
   <>
-    <TextInput {...rest} invalid={isInvalid} hideLabel labelText={label} />
+    <InputWithoutSpinners
+      {...rest}
+      invalid={isInvalid}
+      hideLabel
+      labelText={label}
+    />
     <span className={styles.dot}>.</span>
   </>
 );
@@ -29,7 +34,7 @@ const DEFAULT_MONTH_INPUT = ({
   ...rest
 }: InputComponentProps) => (
   <>
-    <TextInput
+    <InputWithoutSpinners
       {...rest}
       invalid={isInvalid}
       ref={innerRef}
@@ -45,7 +50,7 @@ const DEFAULT_YEAR_INPUT = ({
   label,
   ...rest
 }: InputComponentProps) => (
-  <TextInput
+  <InputWithoutSpinners
     {...rest}
     invalid={isInvalid}
     ref={innerRef}

--- a/src/common/components/dateInput/InputWithoutSpinners.tsx
+++ b/src/common/components/dateInput/InputWithoutSpinners.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { TextInput, TextInputProps } from 'hds-react';
+
+import styles from './inputWithoutSpinners.module.css';
+
+type Props = TextInputProps;
+
+const InputWithoutSpinners = React.forwardRef(
+  ({ className, ...rest }: Props, ref: React.Ref<HTMLInputElement>) => {
+    return (
+      <TextInput
+        ref={ref}
+        {...rest}
+        className={[styles.noSpinner, className].filter(item => item).join(' ')}
+      />
+    );
+  }
+);
+
+export default InputWithoutSpinners;

--- a/src/common/components/dateInput/inputWithoutSpinners.module.css
+++ b/src/common/components/dateInput/inputWithoutSpinners.module.css
@@ -1,0 +1,11 @@
+.noSpinner input{
+  /* Firefox */
+  -moz-appearance: textfield !important;
+}
+
+.noSpinner::-webkit-outer-spin-button input,
+.noSpinner::-webkit-inner-spin-button input {
+  /* Webkit */
+  -webkit-appearance: none;
+  margin: 0;
+}


### PR DESCRIPTION
After this change the birthday input should no longer show spinners on Firefox.