### PR TITLE
Use same presentation logic for array fields

### DIFF
--- a/src/common/components/arrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/src/common/components/arrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,0 +1,74 @@
+import React, { ReactNode } from 'react';
+import { FieldArray, useField, FieldArrayRenderProps } from 'formik';
+import { Button, IconPlusCircle } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+import Stack, { Space } from '../stack/Stack';
+import styles from './arrayFieldTemplate.module.css';
+
+type Props = {
+  name: string;
+  renderField: (value: unknown, index: number, arrayPath: string) => ReactNode;
+  addItemLabel: string;
+  removeItemLabel?: string;
+  onPushItem: (push: (value: unknown) => void) => unknown;
+  space?: Space;
+  listSpace?: Space;
+};
+
+function ArrayFieldTemplate({
+  name,
+  renderField,
+  addItemLabel,
+  removeItemLabel,
+  onPushItem,
+  space = 'm',
+  listSpace = 'l',
+}: Props) {
+  const { t } = useTranslation();
+  const [{ value: values }] = useField(name);
+
+  const removeItemLabelWithDefault =
+    removeItemLabel || t('registration.remove');
+
+  return (
+    <FieldArray
+      name={name}
+      render={(arrayHelpers: FieldArrayRenderProps) => (
+        <Stack space={space}>
+          {Object.keys(values).length > 0 && (
+            <Stack space={listSpace}>
+              {((values as unknown) as Array<unknown>).map(
+                (value, index: number) => (
+                  <div key={index}>
+                    {renderField(value, index, `${name}.${index}`)}
+                    <button
+                      type="button"
+                      className={styles.additionalActionButton}
+                      onClick={() => arrayHelpers.remove(index)}
+                    >
+                      {removeItemLabelWithDefault}
+                    </button>
+                  </div>
+                )
+              )}
+            </Stack>
+          )}
+          <Button
+            type="button"
+            iconLeft={<IconPlusCircle />}
+            variant="supplementary"
+            className={styles.addItemButton}
+            onClick={() => {
+              onPushItem(arrayHelpers.push);
+            }}
+          >
+            {addItemLabel}
+          </Button>
+        </Stack>
+      )}
+    />
+  );
+}
+
+export default ArrayFieldTemplate;

--- a/src/common/components/arrayFieldTemplate/arrayFieldTemplate.module.css
+++ b/src/common/components/arrayFieldTemplate/arrayFieldTemplate.module.css
@@ -1,0 +1,17 @@
+.additionalActionButton {
+  margin-top: var(--spacing-xs);
+  width: fit-content;
+
+  color: var(--color-bus);
+  font-size: var(--fontsize-body-small);
+}
+
+.addItemButton {
+  width: fit-content;
+}
+
+@media (min-width: 540px) {
+  .addItemButton {
+      margin-left: calc(-1 * var(--spacing-m));
+  }
+}

--- a/src/common/components/stack/Stack.tsx
+++ b/src/common/components/stack/Stack.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 import styles from './stack.module.css';
 
-type Space =
+export type Space =
   | '4-xs'
   | '3-xs'
   | '2-xs'
@@ -36,7 +36,7 @@ function transformToCssFriendly(space: Space): CssFriendlySpace {
     case '3-xl':
     case '4-xl':
       return space
-        .split(space)
+        .split('-')
         .reverse()
         .join('-') as CssFriendlySpace;
     default:
@@ -45,7 +45,7 @@ function transformToCssFriendly(space: Space): CssFriendlySpace {
 }
 
 type Props = {
-  children: Array<ReactNode | string>;
+  children: ReactNode;
   component?: 'div' | 'ol' | 'ul';
   space?:
     | '4-xs'

--- a/src/domain/youthProfile/form/YouthProfileAddressTemplate.tsx
+++ b/src/domain/youthProfile/form/YouthProfileAddressTemplate.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from 'react';
+
+import YouthProfileFormGrid from './YouthProfileFormGrid';
+import styles from './youthProfileAddressTemplate.module.css';
+
+type Props = {
+  address: ReactNode;
+  postalCode: ReactNode;
+  city: ReactNode;
+};
+
+function YouthProfileAddressTemplate({ address, postalCode, city }: Props) {
+  return (
+    <YouthProfileFormGrid verticalSpace="small">
+      {address}
+      <div className={styles.addressRowContainer}>
+        {postalCode}
+        {city}
+      </div>
+    </YouthProfileFormGrid>
+  );
+}
+
+export default YouthProfileAddressTemplate;

--- a/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
@@ -1,120 +1,83 @@
 import React from 'react';
-import { Button, IconPlusCircle } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 
-import { FormValues } from './YouthProfileForm';
+import ArrayFieldTemplate from '../../../common/components/arrayFieldTemplate/ArrayFieldTemplate';
+import Stack from '../../../common/components/stack/Stack';
+import YouthProfileFormGrid from './YouthProfileFormGrid';
 import TextInput from './FormikTextInput';
-import styles from './youthProfileForm.module.css';
 
 interface Props {
   approverLabelText: (name: string) => string;
-  formikProps: FormikProps<FormValues>;
 }
 
-function YouthProfileApproverFields({ approverLabelText, formikProps }: Props) {
+function YouthProfileApproverFields({ approverLabelText }: Props) {
   const { t } = useTranslation();
 
   return (
-    <>
-      <div className={styles.formRow}>
+    <Stack space="xl">
+      <YouthProfileFormGrid>
         <TextInput
-          className={styles.formInput}
           id="approverFirstName"
           name="approverFirstName"
           labelText={approverLabelText('firstName')}
         />
         <TextInput
-          className={styles.formInput}
           id="approverLastName"
           name="approverLastName"
           labelText={approverLabelText('lastName')}
         />
-      </div>
-      <div className={styles.formRow}>
         <TextInput
-          className={styles.formInput}
           id="approverEmail"
           name="approverEmail"
           type="email"
           labelText={approverLabelText('email')}
         />
         <TextInput
-          className={styles.formInput}
           id="approverPhone"
           name="approverPhone"
           type="tel"
           labelText={approverLabelText('phoneNumber')}
         />
-      </div>
-      <FieldArray
+      </YouthProfileFormGrid>
+      <ArrayFieldTemplate
         name="additionalContactPersons"
-        render={(arrayHelpers: FieldArrayRenderProps) => (
-          <>
-            {formikProps.values.additionalContactPersons.map(
-              (_: unknown, index: number) => (
-                <div key={index} className={styles.additionalContactGroup}>
-                  <div className={styles.formRow}>
-                    <TextInput
-                      className={styles.formInput}
-                      id={`additionalContactPersons.${index}.firstName`}
-                      name={`additionalContactPersons.${index}.firstName`}
-                      labelText={approverLabelText('firstName')}
-                    />
-                    <TextInput
-                      className={styles.formInput}
-                      id={`additionalContactPersons.${index}.lastName`}
-                      name={`additionalContactPersons.${index}.lastName`}
-                      labelText={approverLabelText('lastName')}
-                    />
-                  </div>
-                  <div className={styles.formRow}>
-                    <TextInput
-                      className={styles.formInput}
-                      id={`additionalContactPersons.${index}.email`}
-                      name={`additionalContactPersons.${index}.email`}
-                      type="email"
-                      labelText={approverLabelText('email')}
-                    />
-                    <TextInput
-                      className={styles.formInput}
-                      id={`additionalContactPersons.${index}.phone`}
-                      name={`additionalContactPersons.${index}.phone`}
-                      type="tel"
-                      labelText={approverLabelText('phoneNumber')}
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.additionalActionButton}
-                    onClick={() => arrayHelpers.remove(index)}
-                  >
-                    {t('registration.remove')}
-                  </button>
-                </div>
-              )
-            )}
-
-            <Button
-              type="button"
-              iconLeft={<IconPlusCircle />}
-              variant="supplementary"
-              className={styles.alignButton}
-              onClick={() => {
-                arrayHelpers.push({
-                  email: '',
-                  firstName: '',
-                  lastName: '',
-                  phone: '',
-                });
-              }}
-            >
-              {t('registration.addGuardian')}
-            </Button>
-          </>
+        renderField={(value, index, arrayPath) => (
+          <YouthProfileFormGrid>
+            <TextInput
+              id={`${arrayPath}.firstName`}
+              name={`${arrayPath}.firstName`}
+              labelText={approverLabelText('firstName')}
+            />
+            <TextInput
+              id={`${arrayPath}.lastName`}
+              name={`${arrayPath}.lastName`}
+              labelText={approverLabelText('lastName')}
+            />
+            <TextInput
+              id={`${arrayPath}.email`}
+              name={`${arrayPath}.email`}
+              type="email"
+              labelText={approverLabelText('email')}
+            />
+            <TextInput
+              id={`${arrayPath}.phone`}
+              name={`${arrayPath}.phone`}
+              type="tel"
+              labelText={approverLabelText('phoneNumber')}
+            />
+          </YouthProfileFormGrid>
         )}
+        addItemLabel={t('registration.addGuardian')}
+        onPushItem={push =>
+          push({
+            email: '',
+            firstName: '',
+            lastName: '',
+            phone: '',
+          })
+        }
       />
-    </>
+    </Stack>
   );
 }
 

--- a/src/domain/youthProfile/form/YouthProfileBasicInformationFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileBasicInformationFields.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, IconPlusCircle } from 'hds-react';
-import { Field, FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
+import { Field, FormikProps } from 'formik';
 import countries from 'i18n-iso-countries';
 import { format } from 'date-fns';
 
 import { AddressType } from '../../../graphql/generatedTypes';
 import getLanguageCode from '../../../common/helpers/getLanguageCode';
 import Select from '../../../common/components/select/Select';
+import ArrayFieldTemplate from '../../../common/components/arrayFieldTemplate/ArrayFieldTemplate';
+import Stack from '../../../common/components/stack/Stack';
 import TextInput from './FormikTextInput';
+import YouthProfileAddressTemplate from './YouthProfileAddressTemplate';
+import YouthProfileFormGrid from './YouthProfileFormGrid';
 import { FormValues, Values } from './YouthProfileForm';
-import styles from './youthProfileForm.module.css';
 
 type Props = {
   profile: Values;
@@ -33,139 +35,122 @@ function YouthProfileFormBasicInformationFields({
   });
 
   return (
-    <>
-      <div className={styles.formRow}>
+    <Stack space="l">
+      <YouthProfileFormGrid>
         <TextInput
-          className={styles.formInput}
           id="firstName"
           name="firstName"
           labelText={t('registration.firstName') + ' *'}
         />
         <TextInput
-          className={styles.formInput}
           id="lastName"
           name="lastName"
           labelText={t('registration.lastName') + ' *'}
         />
-      </div>
-      <div className={styles.formRow}>
-        <Field
-          as={Select}
-          setFieldValue={formikProps.setFieldValue}
-          id="primaryAddress.countryCode"
-          name="primaryAddress.countryCode"
-          type="select"
-          options={countryOptions}
-          className={styles.formInput}
-          labelText={t('registration.country')}
-        />
-      </div>
-      <div className={styles.formRow}>
-        <TextInput
-          className={styles.formInput}
-          id="primaryAddress.address"
-          name="primaryAddress.address"
-          labelText={t('registration.address') + ' *'}
-        />
-        <div className={styles.formInputRow}>
-          <TextInput
-            className={styles.formInputPostal}
-            id="primaryAddress.postalCode"
-            name="primaryAddress.postalCode"
-            inputMode={
-              formikProps.values?.primaryAddress?.countryCode === 'FI'
-                ? 'numeric'
-                : 'text'
-            }
-            labelText={t('registration.postalCode') + ' *'}
+      </YouthProfileFormGrid>
+      <Stack space="s">
+        <YouthProfileFormGrid>
+          <Field
+            as={Select}
+            setFieldValue={formikProps.setFieldValue}
+            id="primaryAddress.countryCode"
+            name="primaryAddress.countryCode"
+            type="select"
+            options={countryOptions}
+            labelText={t('registration.country')}
           />
-          <TextInput
-            className={styles.formInputCity}
-            id="primaryAddress.city"
-            name="primaryAddress.city"
-            labelText={t('registration.city') + ' *'}
-          />
-        </div>
-      </div>
-      <FieldArray
-        name="addresses"
-        render={(arrayHelpers: FieldArrayRenderProps) => (
-          <React.Fragment>
-            {formikProps.values.addresses.map((address, index: number) => (
-              <React.Fragment key={index}>
-                <div className={styles.formRow}>
-                  <Field
-                    as={Select}
-                    setFieldValue={formikProps.setFieldValue}
-                    id={`addresses.${index}.countryCode`}
-                    name={`addresses.${index}.countryCode`}
-                    type="select"
-                    options={countryOptions}
-                    className={styles.formInput}
-                    labelText={t('registration.country')}
-                  />
-                </div>
-                <div className={styles.formRow}>
+        </YouthProfileFormGrid>
+        <YouthProfileAddressTemplate
+          address={
+            <TextInput
+              id="primaryAddress.address"
+              name="primaryAddress.address"
+              labelText={t('registration.address') + ' *'}
+            />
+          }
+          postalCode={
+            <TextInput
+              id="primaryAddress.postalCode"
+              name="primaryAddress.postalCode"
+              inputMode={
+                formikProps.values?.primaryAddress?.countryCode === 'FI'
+                  ? 'numeric'
+                  : 'text'
+              }
+              labelText={t('registration.postalCode') + ' *'}
+            />
+          }
+          city={
+            <TextInput
+              id="primaryAddress.city"
+              name="primaryAddress.city"
+              labelText={t('registration.city') + ' *'}
+            />
+          }
+        />
+      </Stack>
+      <Stack space="m">
+        <ArrayFieldTemplate
+          name="addresses"
+          listSpace="s"
+          renderField={(value, index, namePath) => (
+            <Stack space="s">
+              <YouthProfileFormGrid>
+                <Field
+                  as={Select}
+                  setFieldValue={formikProps.setFieldValue}
+                  id={`${namePath}.countryCode`}
+                  name={`${namePath}.countryCode`}
+                  type="select"
+                  options={countryOptions}
+                  labelText={t('registration.country')}
+                />
+              </YouthProfileFormGrid>
+              <YouthProfileAddressTemplate
+                address={
                   <TextInput
-                    className={styles.formInput}
-                    id={`addresses.${index}.address`}
-                    name={`addresses.${index}.address`}
+                    id={`${namePath}.address`}
+                    name={`${namePath}.address`}
                     labelText={t('registration.address')}
                   />
-
-                  <div className={styles.formInputRow}>
-                    <TextInput
-                      className={styles.formInputPostal}
-                      id={`addresses.${index}.postalCode`}
-                      name={`addresses.${index}.postalCode`}
-                      inputMode={
-                        formikProps.values?.primaryAddress?.countryCode === 'FI'
-                          ? 'numeric'
-                          : 'text'
-                      }
-                      labelText={t('registration.postalCode')}
-                    />
-                    <TextInput
-                      className={styles.formInputCity}
-                      id={`addresses.${index}.city`}
-                      name={`addresses.${index}.city`}
-                      labelText={t('registration.city')}
-                    />
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  className={styles.additionalActionButton}
-                  onClick={() => arrayHelpers.remove(index)}
-                >
-                  {t('registration.remove')}
-                </button>
-              </React.Fragment>
-            ))}
-            <br />
-            <Button
-              type="button"
-              iconLeft={<IconPlusCircle />}
-              className={styles.addAdditional}
-              variant="supplementary"
-              onClick={() =>
-                arrayHelpers.push({
-                  address: '',
-                  postalCode: '',
-                  countryCode: 'FI',
-                  city: '',
-                  primary: false,
-                  addressType: AddressType.OTHER,
-                  __typeName: 'AddressNode',
-                })
-              }
-            >
-              {t('registration.addAddress')}
-            </Button>
-          </React.Fragment>
-        )}
-      />
-      <div className={styles.formRow}>
+                }
+                postalCode={
+                  <TextInput
+                    id={`${namePath}.postalCode`}
+                    name={`${namePath}.postalCode`}
+                    inputMode={
+                      formikProps.values?.primaryAddress?.countryCode === 'FI'
+                        ? 'numeric'
+                        : 'text'
+                    }
+                    labelText={t('registration.postalCode')}
+                  />
+                }
+                city={
+                  <TextInput
+                    id={`${namePath}.city`}
+                    name={`${namePath}.city`}
+                    labelText={t('registration.city')}
+                  />
+                }
+              />
+            </Stack>
+          )}
+          addItemLabel={t('registration.addAddress')}
+          onPushItem={push =>
+            push({
+              address: '',
+              postalCode: '',
+              countryCode: 'FI',
+              city: '',
+              primary: false,
+              addressType: AddressType.OTHER,
+              __typeName: 'AddressNode',
+            })
+          }
+        />
+      </Stack>
+      <YouthProfileFormGrid>
         <Field
           as={TextInput}
           id="birthDate"
@@ -176,7 +161,6 @@ function YouthProfileFormBasicInformationFields({
             format(new Date(profile.birthDate), 'dd.MM.yyyy')
           }
           labelText={t('registration.childBirthDay')}
-          className={styles.formInput}
         />
         <Field
           as={Select}
@@ -189,29 +173,24 @@ function YouthProfileFormBasicInformationFields({
             { value: 'ENGLISH', label: t('LANGUAGE_OPTIONS.ENGLISH') },
             { value: 'SWEDISH', label: t('LANGUAGE_OPTIONS.SWEDISH') },
           ]}
-          className={styles.formInput}
           labelText={t('registration.profileLanguage')}
         />
-      </div>
-      <div className={styles.formRow}>
         <Field
           as={TextInput}
           id="email"
           name="email"
           type="text"
           labelText={t('registration.email')}
-          className={styles.formInput}
           readOnly
         />
         <TextInput
-          className={styles.formInput}
           id="phone"
           name="phone"
           type="tel"
           labelText={t('registration.phoneNumber') + ' *'}
         />
-      </div>
-    </>
+      </YouthProfileFormGrid>
+    </Stack>
   );
 }
 

--- a/src/domain/youthProfile/form/YouthProfileForm.tsx
+++ b/src/domain/youthProfile/form/YouthProfileForm.tsx
@@ -142,7 +142,6 @@ function YouthProfileForm(componentProps: Props) {
               </Text>
 
               <YouthProfileApproverFields
-                formikProps={props}
                 approverLabelText={approverLabelText}
               />
             </PageSection>

--- a/src/domain/youthProfile/form/YouthProfileFormGrid.tsx
+++ b/src/domain/youthProfile/form/YouthProfileFormGrid.tsx
@@ -1,0 +1,22 @@
+import React, { ReactNode } from 'react';
+
+import styles from './youthProfileFormGrid.module.css';
+
+type Props = {
+  children: ReactNode;
+  verticalSpace?: 'default' | 'small';
+};
+
+function YouthProfileFormGrid({ children, verticalSpace = 'default' }: Props) {
+  return (
+    <div
+      className={[styles.formGrid, styles[`vertical-${verticalSpace}`]]
+        .filter(item => item)
+        .join(' ')}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default YouthProfileFormGrid;

--- a/src/domain/youthProfile/form/youthProfileAddressTemplate.module.css
+++ b/src/domain/youthProfile/form/youthProfileAddressTemplate.module.css
@@ -1,0 +1,29 @@
+.addressRowContainer {
+  --gap: var(--spacing-m);
+
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 calc(var(--gap) * -0.5);
+}
+.addressRowContainer > * {
+  margin: 0 calc(var(--gap) * 0.5);
+}
+.addressRowContainer > *:nth-child(1) {
+  flex-grow: 1;
+  flex-basis: 100px;
+}
+.addressRowContainer > *:nth-child(2) {
+  flex-grow: 1;
+  flex-basis: 100px;
+}
+
+@media (min-width: 768px) {
+  .addressRowContainer > *:nth-child(1) {
+    flex-grow: 1;
+    flex-basis: 100px;
+  }
+  .addressRowContainer > *:nth-child(2) {
+    flex-grow: 3;
+    flex-basis: 150px;
+  }
+}

--- a/src/domain/youthProfile/form/youthProfileForm.module.css
+++ b/src/domain/youthProfile/form/youthProfileForm.module.css
@@ -1,4 +1,5 @@
 .formRow {
+    grid-column: 1 / -1;
     display: flex;
     margin-bottom: var(--spacing-s);
     flex-direction: column;
@@ -36,11 +37,6 @@
 
 .addAdditional {
     margin: var(--spacing-layout-2-xs) 0;
-}
-
-.additionalActionButton {
-    color: var(--color-bus);
-    font-size: var(--fontsize-body-small);
 }
 
 @media (min-width: 768px){
@@ -153,9 +149,5 @@ a {
 
     .formTitleText h1 {
         font-size: var(--fontsize-h-1);
-    }
-
-    .alignButton {
-        margin-left: calc(-1 * var(--spacing-m));
     }
 }

--- a/src/domain/youthProfile/form/youthProfileFormGrid.module.css
+++ b/src/domain/youthProfile/form/youthProfileFormGrid.module.css
@@ -1,0 +1,21 @@
+.formGrid {
+  --column-gap: var(--spacing-m); 
+  --row-gap: var(--spacing-m); 
+
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-flow: row;
+  column-gap: var(--column-gap);
+  row-gap: var(--row-gap);
+  max-width: 660px;
+}
+
+.formGrid.vertical-small {
+  --row-gap: var(--spacing-s);
+}
+
+@media (min-width: 768px) {
+  .formGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+}


### PR DESCRIPTION
In this PR I add a common component for array fields. When we have a single field, we can ensure that the array fields behave and look roughly the same.

I also refactored the styles to make use of grids. That way we have less markup and less complex markup. These changes also made it easier to make the array fields consistent with the other fields. Further tweaks to the spacing should now be easier to do.