### PR TITLE
YM-318 | Fix photo usage control in approval view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Authentication info text position
 - Hide spinners from birth day input on Firefox
 - Missing profile language in approval view
+- Fix photo usage approval not working when set from approval view
 
 ## [1.0.0-rc.3]

--- a/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
@@ -56,6 +56,7 @@ function ApproveYouthProfilePage() {
           approverEmail: values.approverEmail,
           approverPhone: values.approverPhone,
           birthDate: data?.youthProfileByApprovalToken?.birthDate,
+          photoUsageApproved: Boolean(values.photoUsageApproved),
         },
         approvalToken: params.token,
       },

--- a/src/domain/youthProfile/approve/confirmApprovingYouthProfile.module.css
+++ b/src/domain/youthProfile/approve/confirmApprovingYouthProfile.module.css
@@ -4,7 +4,3 @@
     justify-content: center;
     flex-direction: column;
 }
-
-.container h1 {
-    margin-bottom: 100px;
-}


### PR DESCRIPTION
Previously the photo usage approval field was not sent when a profile
was accepted. This commit adds it to the request we make to GraphQL.

I also removed the big margin the acceptance approval view had which Anniina mentioned earlier.