### PR TITLE
YM-320 | Add link to Helsinki profile privacy policy

### DIFF
--- a/src/common/components/termsField/TermsField.tsx
+++ b/src/common/components/termsField/TermsField.tsx
@@ -36,6 +36,12 @@ function TermsField(props: Props) {
                 />,
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
                 <a
+                  href={t('privacyPolicy.helsinkiProfileLink')}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />,
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                <a
                   href={t('privacyPolicy.descriptionLink')}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -962,6 +962,11 @@ exports[`matches snapshot 1`] = `
                                   target="_blank"
                                 />,
                                 <a
+                                  href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                />,
+                                <a
                                   href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
                                   rel="noopener noreferrer"
                                   target="_blank"
@@ -1009,6 +1014,11 @@ exports[`matches snapshot 1`] = `
                                     target="_blank"
                                   />,
                                   <a
+                                    href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                    rel="noopener noreferrer"
+                                    target="_blank"
+                                  />,
+                                  <a
                                     href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
                                     rel="noopener noreferrer"
                                     target="_blank"
@@ -1017,25 +1027,34 @@ exports[`matches snapshot 1`] = `
                               }
                               i18nKey="approval.approveTerms"
                             >
-                              Olen tutustunut palvelun 
+                              Olen tutustunut 
                               <a
                                 href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
                                 key="1"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
-                                rekisteriselosteeseen
+                                tämän palvelun rekisteriselosteeseen
                               </a>
-                               ja kaupungin 
+                              , 
                               <a
-                                href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
+                                href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
                                 key="3"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
-                                tietosuojakäytäntöön
+                                Helsinki-profiilin rekisteriselosteeseen
                               </a>
-                                ja että minuun voidaan olla yhteydessä antamaani osoitteeseen.
+                               ja 
+                              <a
+                                href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
+                                key="5"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                kaupungin tietosuojakäytäntöön
+                              </a>
+                              . Minuun voidaan olla yhteydessä antamieni tietojen avulla.
                             </Trans>
                           </span>
                         </label>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,7 +14,7 @@
     "approverInfo": "Approver info",
     "approverInfoText": "Guardian may be contacted concerning the child.",
     "approverLastName": "Lastname",
-    "approveTerms": "I have read <0>file description</0> and  city's <1>data protection principles</1>. I can be contacted via address I have given.",
+    "approveTerms": "I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
     "approveTermsText_link": "service terms",
     "basicInfo": "Basic info",
     "birthDate": "Birthdate",
@@ -103,7 +103,8 @@
     "authenticating": "Authenticating..."
   },
   "privacyPolicy": {
-    "descriptionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection"
+    "descriptionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profile": {
     "address": "Address",
@@ -120,7 +121,7 @@
     "approver": "Approver",
     "approverInfoOver18Text": "For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
     "approverInfoText": "A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
-    "approveTerms": "I have read <0>file description</0> and  city's <1>data protection principles</1>. I can be contacted via address I have given.",
+    "approveTerms": "I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
     "basicInfo": "Basic info",
     "birthdayHelper": "Birthdate (dd.mm.yyyy) *",
     "birthdayInvalid": "The birthday should be dd.mm.yyyy.",
@@ -131,6 +132,7 @@
     "city": "City",
     "confirmSend": "Accept the terms and send the application",
     "country": "Country",
+    "dateInvalid": "The date does not exist",
     "email": "Email",
     "firstName": "Firstname",
     "languageAtHome": "Language at home",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -14,7 +14,7 @@
     "approverInfo": "Huoltajan tiedot",
     "approverInfoText": "Huoltajaan voidaan olla yhteydessä lasta koskevissa asioissa.",
     "approverLastName": "Sukunimi",
-    "approveTerms": "Olen tutustunut palvelun <0>rekisteriselosteeseen</0> ja kaupungin <1>tietosuojakäytäntöön</1>  ja että minuun voidaan olla yhteydessä antamaani osoitteeseen.",
+    "approveTerms": "Olen tutustunut <0>tämän palvelun rekisteriselosteeseen</0>, <1>Helsinki-profiilin rekisteriselosteeseen</1> ja <2>kaupungin tietosuojakäytäntöön</2>. Minuun voidaan olla yhteydessä antamieni tietojen avulla.",
     "approveTermsText_link": "palvelun ehdot",
     "basicInfo": "Perustiedot",
     "birthDate": "Syntymäpäivä",
@@ -103,7 +103,8 @@
     "authenticating": "Tunnistaudutaan..."
   },
   "privacyPolicy": {
-    "descriptionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
+    "descriptionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/",
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profile": {
     "address": "Osoite",
@@ -120,7 +121,7 @@
     "approver": "Huoltajan tiedot",
     "approverInfoOver18Text": "Yli 18-vuotiaalta emme edellytä vanhemman yhteystietojen lisäämistä. Mutta mikäli syystä tai toisesta koet tarpeelliseksi, että voimme tarvittaessa olla yhteydessä huoltajaasi, voit lisätä yhteystiedon tähän. ",
     "approverInfoText": "Vahvistuspyyntö jäsenyydestäsi lähetetään tähän osoitteeseen, huoltaja varmistaa tiedot ja hyväksyy jäsenyyden.",
-    "approveTerms": "Olen tutustunut palvelun <0>rekisteriselosteeseen</0> ja kaupungin <1>tietosuojakäytäntöön</1>  ja että minuun voidaan olla yhteydessä antamaani osoitteeseen.",
+    "approveTerms": "Olen tutustunut <0>tämän palvelun rekisteriselosteeseen</0>, <1>Helsinki-profiilin rekisteriselosteeseen</1> ja <2>kaupungin tietosuojakäytäntöön</2>. Minuun voidaan olla yhteydessä antamieni tietojen avulla.",
     "basicInfo": "Perustiedot",
     "birthdayHelper": "Syntymäpäivä (pp.kk.vvvv) *",
     "birthdayInvalid": "Syntymäpäivän tulee olla muotoa pp.kk.vvvv.",
@@ -131,6 +132,7 @@
     "city": "Kaupunki",
     "confirmSend": "Hyväksy ehdot ja lähetä hakemus",
     "country": "Maa",
+    "dateInvalid": "Päivää ei ole olemassa",
     "email": "Sähköpostiosoite",
     "firstName": "Etunimi",
     "languageAtHome": "Kotona puhuttu kieli",
@@ -142,7 +144,7 @@
     "photoUsageApprovedText": "Minusta voi ottaa kuvia ja niitä saa käyttää Helsingin kaupungin viestinnässä ja markkinoinnissa painetussa ja sähköisessä mediassa. Kuvaamisesta ja kuvien käytöstä ei makseta korvausta. Oikeus kuvien käyttöön on aina voimassa ja koskee koko Helsingin kaupungin viestintää ja markkinointiviestintää.",
     "photoUsageApprovedYes": "Kyllä",
     "postalCode": "Postinumero",
-    "processInfoText": "Tietojen varmennuskysely lähetetään vanhemmalla ja kun tämä on tarkastanut ja hyväksynyt tiedot, jäsenyytesi astuu voimaan.",
+    "processInfoText": "Tietojen varmennuskysely lähetetään vanhemmalle ja kun tämä on tarkastanut ja hyväksynyt tiedot, jäsenyytesi astuu voimaan.",
     "profileLanguage": "Profiilin kieli",
     "save": "Tallenna tiedot",
     "schoolClass": "Luokka",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -14,7 +14,7 @@
     "approverInfo": "Vårdnadshavarens uppgifter",
     "approverInfoText": "Vårdnadshavaren får kan kontaktas angående barnet.",
     "approverLastName": "Efternamn",
-    "approveTerms": "Jag har läst filen <0>beskrivningen</0> och stads <1>sekretesspolicy</1>. Jag kan kontaktas via den adress jag har angett.",
+    "approveTerms": "Jag har läst <0>sekretesspolicyn för denna tjänst</0>, <1>sekretesspolicyn för Helsingfors-profil</1> och <2>stadens dataskyddsprinciper</2>. Jag kan kontaktas med hjälp av den information jag har gett.",
     "approveTermsText_link": "servicevillkor",
     "basicInfo": "Basuppgifter",
     "birthDate": "Födelsedatum",
@@ -102,7 +102,8 @@
     "authenticating": "Autentiserar..."
   },
   "privacyPolicy": {
-    "descriptionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd"
+    "descriptionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd",
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
   },
   "profile": {
     "address": "Adress",
@@ -119,7 +120,7 @@
     "approver": "Vårdnadshavarens uppgifter",
     "approverInfoOver18Text": "För medlemmar över 18 år förutsätts inte vårdnadshavaren kontaktuppgifter. Om du av någon anledning vill att vi ska kunna kontakta din vårdnadshavare kan du lägga till informationen här",
     "approverInfoText": "Begäran om bekräftelse av ditt medlemskap skickas till denna adress. Vårdnadshavaren kontrollerar uppgifterna och godkänner medlemskapet.",
-    "approveTerms": "Jag har läst filen <0>beskrivningen</0> och stads <1>sekretesspolicy</1>. Jag kan kontaktas via den adress jag har angett.",
+    "approveTerms": "Jag har läst <0>sekretesspolicyn för denna tjänst</0>, <1>sekretesspolicyn för Helsingfors-profil</1> och <2>stadens dataskyddsprinciper</2>. Jag kan kontaktas med hjälp av den information jag har gett.",
     "basicInfo": "Basuppgifter",
     "birthdayHelper": "Födelsedatum (dd.mm.åååå) *",
     "birthdayInvalid": "Födelsedagen bör vara dd.mm.åååå.",
@@ -130,6 +131,7 @@
     "city": "Stad",
     "confirmSend": "Godkänn villkoren och skicka ansökan",
     "country": "Land",
+    "dateInvalid": "Datumet finns inte",
     "email": "E-post",
     "firstName": "Förnamn",
     "languageAtHome": "Hemspråk",


### PR DESCRIPTION
Updated the latest translations from the Excel which now contained the link
to Helsinki profile privacy policy + updated texts for terms approval.

Changed the terms approval so that it now adds a link which points to the
Helsinki profile privacy policy so that the user is at least minimally
notified of that registry.