### PR TITLE
YM-322 | Fix profile information page crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [1.0.1] - 2020-08-31
+### Fixed
+- Fixed issue where application would crash when entering `Profile information` page.
+
 ## [1.0.0] - 2020-08-28
 ### Changed
 - Form fields are now validated on blur

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youth-membership-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/common/test/membershipDetailsData.ts
+++ b/src/common/test/membershipDetailsData.ts
@@ -11,6 +11,7 @@ export const membershipDetailsData: MembershipDetails = {
       firstName: 'Teemu',
       lastName: 'Testaaja',
       language: Language.FINNISH,
+      id: '123asd',
       primaryPhone: {
         id: '123',
         phone: '0501234567',

--- a/src/domain/membership/graphql/MembershipDetailsFragment.graphql
+++ b/src/domain/membership/graphql/MembershipDetailsFragment.graphql
@@ -3,6 +3,7 @@ fragment MembershipDetailsFragment on YouthProfileType {
     firstName
     lastName
     language
+    id
     primaryAddress {
       address
       postalCode

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -74,6 +74,10 @@ export interface MembershipDetails_youthProfile_profile {
   readonly lastName: string;
   readonly language: Language | null;
   /**
+   * The ID of the object.
+   */
+  readonly id: string;
+  /**
    * Convenience field for the address which is marked as primary.
    */
   readonly primaryAddress: MembershipDetails_youthProfile_profile_primaryAddress | null;
@@ -734,6 +738,10 @@ export interface YouthProfileByApprovalToken_youthProfileByApprovalToken_profile
   readonly lastName: string;
   readonly language: Language | null;
   /**
+   * The ID of the object.
+   */
+  readonly id: string;
+  /**
    * Convenience field for the address which is marked as primary.
    */
   readonly primaryAddress: YouthProfileByApprovalToken_youthProfileByApprovalToken_profile_primaryAddress | null;
@@ -893,6 +901,10 @@ export interface MembershipDetailsFragment_profile {
   readonly firstName: string;
   readonly lastName: string;
   readonly language: Language | null;
+  /**
+   * The ID of the object.
+   */
+  readonly id: string;
   /**
    * Convenience field for the address which is marked as primary.
    */


### PR DESCRIPTION
Because `MembershipDetailsFragment` was missing profile ID, it caused Apollo cache to crash when fetching new information. 