### PR TITLE
YM-180 | Allow approver to edit additional contact persons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased]
+### Added
+- Approvers can now control additional contact persons
+
 ## [1.0.1] - 2020-08-31
 ### Fixed
 - Fixed issue where application would crash when entering `Profile information` page.

--- a/src/domain/youthProfile/approve/ApproveYouthProfile.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfile.tsx
@@ -6,6 +6,7 @@ import convertBooleanToString from '../../../common/helpers/convertBooleanToStri
 import PageSection from '../../../common/components/layout/PageSection';
 import getAddress from '../../membership/helpers/getAddress';
 import getAddresses from '../../membership/helpers/getAddresses';
+import getAdditionalContactPersons from '../helpers/getAdditionalContactPersons';
 import ConfirmApprovingYouthProfile from './ConfirmApprovingYouthProfile';
 import ApproveYouthProfileForm, { FormValues } from './ApproveYouthProfileForm';
 
@@ -56,6 +57,9 @@ function ApproveYouthProfile({ isApprovalSuccessful, data, onSubmit }: Props) {
             ),
             languageAtHome:
               data?.youthProfileByApprovalToken?.languageAtHome || '',
+            additionalContactPersons: getAdditionalContactPersons(
+              data?.youthProfileByApprovalToken
+            ),
           }}
           onSubmit={onSubmit}
         />

--- a/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
@@ -70,14 +70,14 @@ function ApproveYouthProfileForm(props: Props) {
       {props => (
         <Stack space="xl">
           <div>
-            <Text variant="h2">{t('approval.title')}</Text>
+            <Text variant="h1">{t('approval.title')}</Text>
             <Text variant="info">
               {props.values.firstName} {t('approval.formExplanationText_1')}{' '}
               {props.values.firstName} {t('approval.formExplanationText_2')}
             </Text>
           </div>
           <div>
-            <Text variant="h3">{t('approval.basicInfo')}</Text>
+            <Text variant="h2">{t('approval.basicInfo')}</Text>
             <BasicInformationGrid
               name={`${props.values.firstName} ${props.values.lastName}`}
               addresses={[props.values.address, ...props.values.addresses]}
@@ -88,7 +88,7 @@ function ApproveYouthProfileForm(props: Props) {
             />
           </div>
           <div>
-            <Text variant="h3">{t('approval.addInfo')}</Text>
+            <Text variant="h2">{t('approval.addInfo')}</Text>
             <InfoGrid>
               <LabeledValue
                 label={t('approval.schoolInfo')}
@@ -107,8 +107,8 @@ function ApproveYouthProfileForm(props: Props) {
               <div>
                 {age < ageConstants.PHOTO_PERMISSION_MIN && (
                   <React.Fragment>
-                    <Text variant="h3">{t('approval.approverAcceptance')}</Text>
-                    <Text variant="h4">{t('approval.photoUsageApproved')}</Text>
+                    <Text variant="h2">{t('approval.approverAcceptance')}</Text>
+                    <Text variant="h3">{t('approval.photoUsageApproved')}</Text>
                     <Text variant="info">
                       {t('approval.photoUsageApprovedText')}
                     </Text>
@@ -142,7 +142,7 @@ function ApproveYouthProfileForm(props: Props) {
                 )}
               </div>
               <div>
-                <Text variant="h3">{t('approval.approverInfo')}</Text>
+                <Text variant="h2">{t('approval.approverInfo')}</Text>
                 <Text variant="info">{t('approval.approverInfoText')}</Text>
                 <YouthProfileApproverFields />
               </div>

--- a/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
@@ -3,8 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { differenceInYears } from 'date-fns';
-import { Button, TextInput, RadioButton } from 'hds-react';
+import { Button, RadioButton } from 'hds-react';
 
+import {
+  CreateAdditionalContactPersonInput,
+  UpdateAdditionalContactPersonInput,
+} from '../../../graphql/generatedTypes';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import LabeledValue from '../../../common/components/labeledValue/LabeledValue';
 import Text from '../../../common/components/text/Text';
@@ -12,6 +16,7 @@ import Stack from '../../../common/components/stack/Stack';
 import TermsField from '../../../common/components/termsField/TermsField';
 import BasicInformationGrid from '../../../common/components/basicInformationGrid/BasicInformationGrid';
 import InfoGrid from '../../../common/components/infoGrid/InfoGrid';
+import YouthProfileApproverFields from '../../youthProfile/form/YouthProfileApproverFields';
 import ageConstants from '../constants/ageConstants';
 import styles from './approveYouthProfileForm.module.css';
 
@@ -42,6 +47,10 @@ export type FormValues = {
   approverEmail: string;
   photoUsageApproved: string;
   languageAtHome: string;
+  additionalContactPersons: (
+    | CreateAdditionalContactPersonInput
+    | UpdateAdditionalContactPersonInput
+  )[];
 };
 
 type Props = {
@@ -145,64 +154,7 @@ function ApproveYouthProfileForm(props: Props) {
               <div>
                 <Text variant="h3">{t('approval.approverInfo')}</Text>
                 <Text variant="info">{t('approval.approverInfoText')}</Text>
-                <div className={styles.formFields}>
-                  <Field
-                    className={styles.formField}
-                    as={TextInput}
-                    id="approverFirstName"
-                    name="approverFirstName"
-                    invalid={
-                      props.submitCount && props.errors.approverFirstName
-                    }
-                    helperText={
-                      props.submitCount && props.errors.approverFirstName
-                        ? t(props.errors.approverFirstName)
-                        : ''
-                    }
-                    labelText={t('approval.approverFirstName')}
-                  />
-                  <Field
-                    className={styles.formField}
-                    as={TextInput}
-                    id="approverLastName"
-                    name="approverLastName"
-                    invalid={props.submitCount && props.errors.approverLastName}
-                    helperText={
-                      props.submitCount && props.errors.approverLastName
-                        ? t(props.errors.approverLastName)
-                        : ''
-                    }
-                    labelText={t('approval.approverLastName')}
-                  />
-                  <Field
-                    className={styles.formField}
-                    as={TextInput}
-                    id="approverEmail"
-                    name="approverEmail"
-                    type="email"
-                    invalid={props.submitCount && props.errors.phone}
-                    helperText={
-                      props.submitCount && props.errors.phone
-                        ? t(props.errors.phone)
-                        : ''
-                    }
-                    labelText={t('approval.approverEmail')}
-                  />
-                  <Field
-                    className={styles.formField}
-                    as={TextInput}
-                    id="approverPhone"
-                    name="approverPhone"
-                    type="tel"
-                    invalid={props.submitCount && props.errors.phone}
-                    helperText={
-                      props.submitCount && props.errors.phone
-                        ? t(props.errors.phone)
-                        : ''
-                    }
-                    labelText={t('approval.phone')}
-                  />
-                </div>
+                <YouthProfileApproverFields youthAge={age} />
               </div>
               <TermsField id="terms" name="terms" />
               <Button className={styles.button} type="submit">

--- a/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Field, Form, Formik } from 'formik';
-import * as Yup from 'yup';
 import { differenceInYears } from 'date-fns';
 import { Button, RadioButton } from 'hds-react';
 
@@ -17,18 +16,9 @@ import TermsField from '../../../common/components/termsField/TermsField';
 import BasicInformationGrid from '../../../common/components/basicInformationGrid/BasicInformationGrid';
 import InfoGrid from '../../../common/components/infoGrid/InfoGrid';
 import YouthProfileApproverFields from '../../youthProfile/form/YouthProfileApproverFields';
+import { approveYouthProfileFormSchema } from '../youthProfileSchemas';
 import ageConstants from '../constants/ageConstants';
 import styles from './approveYouthProfileForm.module.css';
-
-const schema = Yup.object().shape({
-  approverFirstName: Yup.string().max(255, 'validation.maxLength'),
-  approverLastName: Yup.string().max(255, 'validation.maxLength'),
-  approverEmail: Yup.string().max(255, 'validation.maxLength'),
-  phone: Yup.string()
-    .min(6, 'validation.phoneMin')
-    .max(255, 'validation.maxLength'),
-  terms: Yup.boolean().oneOf([true], 'validation.required'),
-});
 
 export type FormValues = {
   firstName: string;
@@ -74,7 +64,7 @@ function ApproveYouthProfileForm(props: Props) {
         terms: false,
       }}
       onSubmit={({ terms, ...values }) => props.onSubmit(values)}
-      validationSchema={schema}
+      validationSchema={approveYouthProfileFormSchema}
       enableReinitialize={true}
     >
       {props => (
@@ -154,7 +144,7 @@ function ApproveYouthProfileForm(props: Props) {
               <div>
                 <Text variant="h3">{t('approval.approverInfo')}</Text>
                 <Text variant="info">{t('approval.approverInfoText')}</Text>
-                <YouthProfileApproverFields youthAge={age} />
+                <YouthProfileApproverFields />
               </div>
               <TermsField id="terms" name="terms" />
               <Button className={styles.button} type="submit">

--- a/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
@@ -9,10 +9,14 @@ import {
   YouthProfileByApprovalToken,
   ApproveYouthProfile as ApproveYourProfileData,
   ApproveYouthProfileVariables,
+  CreateAdditionalContactPersonInput,
+  UpdateAdditionalContactPersonInput,
 } from '../../../graphql/generatedTypes';
 import NotificationComponent from '../../../common/components/notification/NotificationComponent';
 import PageContent from '../../../common/components/layout/PageContent';
 import PageSection from '../../../common/components/layout/PageSection';
+import prepareArrayFieldChanges from '../helpers/prepareArrayFieldChanges';
+import getAdditionalContactPersons from '../helpers/getAdditionalContactPersons';
 import { FormValues } from './ApproveYouthProfileForm';
 import ApproveYouthProfile from './ApproveYouthProfile';
 
@@ -48,6 +52,13 @@ function ApproveYouthProfilePage() {
   >(APPROVE_PROFILE);
 
   const handleOnSubmit = async (values: FormValues) => {
+    const previousAdditionalContactPersons = getAdditionalContactPersons(
+      data?.youthProfileByApprovalToken
+    );
+    const { add, update, remove } = prepareArrayFieldChanges<
+      CreateAdditionalContactPersonInput,
+      UpdateAdditionalContactPersonInput
+    >(previousAdditionalContactPersons, values.additionalContactPersons);
     const variables = {
       input: {
         approvalData: {
@@ -57,6 +68,9 @@ function ApproveYouthProfilePage() {
           approverPhone: values.approverPhone,
           birthDate: data?.youthProfileByApprovalToken?.birthDate,
           photoUsageApproved: Boolean(values.photoUsageApproved),
+          addAdditionalContactPersons: add,
+          updateAdditionalContactPersons: update,
+          removeAdditionalContactPersons: remove,
         },
         approvalToken: params.token,
       },

--- a/src/domain/youthProfile/approve/__test__/ApproveYouthProfileForm.test.tsx
+++ b/src/domain/youthProfile/approve/__test__/ApproveYouthProfileForm.test.tsx
@@ -26,6 +26,7 @@ const defaultProps = {
     approverLastName: 'Vanhempi',
     approverEmail: 'ville.vanhempi@test.fi',
     approverPhone: '05012345567',
+    additionalContactPersons: [],
   } as FormValues,
   isSubmitting: false,
   onSubmit: jest.fn(),

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -68,11 +68,12 @@ exports[`matches snapshot 1`] = `
         "_exclusive": Object {},
         "_mutate": undefined,
         "_nodes": Array [
-          "terms",
+          "additionalContactPersons",
           "phone",
           "approverEmail",
           "approverLastName",
           "approverFirstName",
+          "terms",
         ],
         "_options": Object {
           "abortEarly": true,
@@ -85,6 +86,176 @@ exports[`matches snapshot 1`] = `
           "refs": Map {},
         },
         "fields": Object {
+          "additionalContactPersons": ArraySchema {
+            "_blacklist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "_conditions": Array [],
+            "_deps": Array [],
+            "_exclusive": Object {},
+            "_mutate": undefined,
+            "_options": Object {
+              "abortEarly": true,
+              "recursive": true,
+            },
+            "_subType": ObjectSchema {
+              "_blacklist": RefSet {
+                "list": Set {},
+                "refs": Map {},
+              },
+              "_conditions": Array [],
+              "_defaultDefault": [Function],
+              "_deps": Array [],
+              "_excludedEdges": Array [],
+              "_exclusive": Object {},
+              "_mutate": undefined,
+              "_nodes": Array [
+                "email",
+                "phone",
+                "lastName",
+                "firstName",
+              ],
+              "_options": Object {
+                "abortEarly": true,
+                "recursive": true,
+              },
+              "_type": "object",
+              "_typeError": [Function],
+              "_whitelist": RefSet {
+                "list": Set {},
+                "refs": Map {},
+              },
+              "fields": Object {
+                "email": StringSchema {
+                  "_blacklist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "_conditions": Array [],
+                  "_deps": Array [],
+                  "_exclusive": Object {
+                    "required": true,
+                  },
+                  "_mutate": undefined,
+                  "_options": Object {
+                    "abortEarly": true,
+                    "recursive": true,
+                  },
+                  "_type": "string",
+                  "_typeError": [Function],
+                  "_whitelist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "tests": Array [
+                    [Function],
+                  ],
+                  "transforms": Array [
+                    [Function],
+                  ],
+                },
+                "firstName": StringSchema {
+                  "_blacklist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "_conditions": Array [],
+                  "_deps": Array [],
+                  "_exclusive": Object {
+                    "required": true,
+                  },
+                  "_mutate": undefined,
+                  "_options": Object {
+                    "abortEarly": true,
+                    "recursive": true,
+                  },
+                  "_type": "string",
+                  "_typeError": [Function],
+                  "_whitelist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "tests": Array [
+                    [Function],
+                  ],
+                  "transforms": Array [
+                    [Function],
+                  ],
+                },
+                "lastName": StringSchema {
+                  "_blacklist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "_conditions": Array [],
+                  "_deps": Array [],
+                  "_exclusive": Object {
+                    "required": true,
+                  },
+                  "_mutate": undefined,
+                  "_options": Object {
+                    "abortEarly": true,
+                    "recursive": true,
+                  },
+                  "_type": "string",
+                  "_typeError": [Function],
+                  "_whitelist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "tests": Array [
+                    [Function],
+                  ],
+                  "transforms": Array [
+                    [Function],
+                  ],
+                },
+                "phone": StringSchema {
+                  "_blacklist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "_conditions": Array [],
+                  "_deps": Array [],
+                  "_exclusive": Object {
+                    "required": true,
+                  },
+                  "_mutate": undefined,
+                  "_options": Object {
+                    "abortEarly": true,
+                    "recursive": true,
+                  },
+                  "_type": "string",
+                  "_typeError": [Function],
+                  "_whitelist": RefSet {
+                    "list": Set {},
+                    "refs": Map {},
+                  },
+                  "tests": Array [
+                    [Function],
+                  ],
+                  "transforms": Array [
+                    [Function],
+                  ],
+                },
+              },
+              "tests": Array [],
+              "transforms": Array [
+                [Function],
+              ],
+            },
+            "_type": "array",
+            "_typeError": [Function],
+            "_whitelist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "tests": Array [],
+            "transforms": Array [
+              [Function],
+            ],
+          },
           "approverEmail": StringSchema {
             "_blacklist": RefSet {
               "list": Set {},
@@ -93,7 +264,8 @@ exports[`matches snapshot 1`] = `
             "_conditions": Array [],
             "_deps": Array [],
             "_exclusive": Object {
-              "max": true,
+              "required": true,
+              "undefined": false,
             },
             "_mutate": undefined,
             "_options": Object {
@@ -107,6 +279,7 @@ exports[`matches snapshot 1`] = `
               "refs": Map {},
             },
             "tests": Array [
+              [Function],
               [Function],
             ],
             "transforms": Array [
@@ -122,6 +295,8 @@ exports[`matches snapshot 1`] = `
             "_deps": Array [],
             "_exclusive": Object {
               "max": true,
+              "min": true,
+              "required": true,
             },
             "_mutate": undefined,
             "_options": Object {
@@ -135,6 +310,8 @@ exports[`matches snapshot 1`] = `
               "refs": Map {},
             },
             "tests": Array [
+              [Function],
+              [Function],
               [Function],
             ],
             "transforms": Array [
@@ -150,6 +327,8 @@ exports[`matches snapshot 1`] = `
             "_deps": Array [],
             "_exclusive": Object {
               "max": true,
+              "min": true,
+              "required": true,
             },
             "_mutate": undefined,
             "_options": Object {
@@ -164,6 +343,8 @@ exports[`matches snapshot 1`] = `
             },
             "tests": Array [
               [Function],
+              [Function],
+              [Function],
             ],
             "transforms": Array [
               [Function],
@@ -177,8 +358,8 @@ exports[`matches snapshot 1`] = `
             "_conditions": Array [],
             "_deps": Array [],
             "_exclusive": Object {
-              "max": true,
               "min": true,
+              "required": true,
             },
             "_mutate": undefined,
             "_options": Object {
@@ -229,6 +410,7 @@ exports[`matches snapshot 1`] = `
         },
         "tests": Array [],
         "transforms": Array [
+          [Function],
           [Function],
         ],
       }
@@ -670,9 +852,7 @@ exports[`matches snapshot 1`] = `
                       Huoltajaan voidaan olla yhteydessä lasta koskevissa asioissa.
                     </p>
                   </Text>
-                  <YouthProfileApproverFields
-                    youthAge={14}
-                  >
+                  <YouthProfileApproverFields>
                     <Stack
                       space="xl"
                     >

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`matches snapshot 1`] = `
   onSubmit={[MockFunction]}
   profile={
     Object {
+      "additionalContactPersons": Array [],
       "address": "Testikuja 55, 00100 Helsinki",
       "addresses": Array [
         "Kymintie 43, 00100 Helsinki",
@@ -31,6 +32,7 @@ exports[`matches snapshot 1`] = `
     enableReinitialize={true}
     initialValues={
       Object {
+        "additionalContactPersons": Array [],
         "address": "Testikuja 55, 00100 Helsinki",
         "addresses": Array [
           "Kymintie 43, 00100 Helsinki",
@@ -668,278 +670,415 @@ exports[`matches snapshot 1`] = `
                       Huoltajaan voidaan olla yhteydessä lasta koskevissa asioissa.
                     </p>
                   </Text>
-                  <div
-                    className="formFields"
+                  <YouthProfileApproverFields
+                    youthAge={14}
                   >
-                    <Field
-                      as={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "render": [Function],
-                        }
-                      }
-                      className="formField"
-                      helperText=""
-                      id="approverFirstName"
-                      invalid={0}
-                      labelText="Etunimi"
-                      name="approverFirstName"
+                    <Stack
+                      space="xl"
                     >
-                      <ForwardRef
-                        className="formField"
-                        helperText=""
-                        id="approverFirstName"
-                        invalid={0}
-                        labelText="Etunimi"
-                        name="approverFirstName"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        value="Ville"
+                      <div
+                        className="stack xl"
                       >
-                        <InputWrapper
-                          className="formField"
-                          helperText=""
-                          id="approverFirstName"
-                          invalid={0}
-                          labelText="Etunimi"
-                        >
+                        <YouthProfileFormGrid>
                           <div
-                            className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6 formField"
+                            className="formGrid vertical-default"
                           >
-                            <FieldLabel
-                              hidden={false}
-                              inputId="approverFirstName"
-                              label="Etunimi"
-                              required={false}
+                            <FormikTestInput
+                              id="approverFirstName"
+                              labelText="Etunimi *"
+                              name="approverFirstName"
                             >
-                              <label
-                                className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-                                htmlFor="approverFirstName"
-                              >
-                                Etunimi
-                              </label>
-                            </FieldLabel>
-                            <div
-                              className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
-                            >
-                              <input
-                                className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
-                                disabled={false}
-                                id="approverFirstName"
+                              <Field
                                 name="approverFirstName"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="text"
-                                value="Ville"
-                              />
-                            </div>
-                          </div>
-                        </InputWrapper>
-                      </ForwardRef>
-                    </Field>
-                    <Field
-                      as={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "render": [Function],
-                        }
-                      }
-                      className="formField"
-                      helperText=""
-                      id="approverLastName"
-                      invalid={0}
-                      labelText="Sukunimi"
-                      name="approverLastName"
-                    >
-                      <ForwardRef
-                        className="formField"
-                        helperText=""
-                        id="approverLastName"
-                        invalid={0}
-                        labelText="Sukunimi"
-                        name="approverLastName"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        value="Vanhempi"
-                      >
-                        <InputWrapper
-                          className="formField"
-                          helperText=""
-                          id="approverLastName"
-                          invalid={0}
-                          labelText="Sukunimi"
-                        >
-                          <div
-                            className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6 formField"
-                          >
-                            <FieldLabel
-                              hidden={false}
-                              inputId="approverLastName"
-                              label="Sukunimi"
-                              required={false}
-                            >
-                              <label
-                                className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-                                htmlFor="approverLastName"
                               >
-                                Sukunimi
-                              </label>
-                            </FieldLabel>
-                            <div
-                              className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                <ForwardRef
+                                  id="approverFirstName"
+                                  invalid={false}
+                                  labelText="Etunimi *"
+                                  name="approverFirstName"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  value="Ville"
+                                >
+                                  <InputWrapper
+                                    className=""
+                                    id="approverFirstName"
+                                    invalid={false}
+                                    labelText="Etunimi *"
+                                  >
+                                    <div
+                                      className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6"
+                                    >
+                                      <FieldLabel
+                                        hidden={false}
+                                        inputId="approverFirstName"
+                                        label="Etunimi *"
+                                        required={false}
+                                      >
+                                        <label
+                                          className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
+                                          htmlFor="approverFirstName"
+                                        >
+                                          Etunimi *
+                                        </label>
+                                      </FieldLabel>
+                                      <div
+                                        className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                      >
+                                        <input
+                                          className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
+                                          disabled={false}
+                                          id="approverFirstName"
+                                          name="approverFirstName"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          type="text"
+                                          value="Ville"
+                                        />
+                                      </div>
+                                    </div>
+                                  </InputWrapper>
+                                </ForwardRef>
+                              </Field>
+                            </FormikTestInput>
+                            <FormikTestInput
+                              id="approverLastName"
+                              labelText="Sukunimi *"
+                              name="approverLastName"
                             >
-                              <input
-                                className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
-                                disabled={false}
-                                id="approverLastName"
+                              <Field
                                 name="approverLastName"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="text"
-                                value="Vanhempi"
-                              />
-                            </div>
-                          </div>
-                        </InputWrapper>
-                      </ForwardRef>
-                    </Field>
-                    <Field
-                      as={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "render": [Function],
-                        }
-                      }
-                      className="formField"
-                      helperText=""
-                      id="approverEmail"
-                      invalid={0}
-                      labelText="Sähköposti"
-                      name="approverEmail"
-                      type="email"
-                    >
-                      <ForwardRef
-                        className="formField"
-                        helperText=""
-                        id="approverEmail"
-                        invalid={0}
-                        labelText="Sähköposti"
-                        name="approverEmail"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        type="email"
-                        value="ville.vanhempi@test.fi"
-                      >
-                        <InputWrapper
-                          className="formField"
-                          helperText=""
-                          id="approverEmail"
-                          invalid={0}
-                          labelText="Sähköposti"
-                        >
-                          <div
-                            className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6 formField"
-                          >
-                            <FieldLabel
-                              hidden={false}
-                              inputId="approverEmail"
-                              label="Sähköposti"
-                              required={false}
-                            >
-                              <label
-                                className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-                                htmlFor="approverEmail"
                               >
-                                Sähköposti
-                              </label>
-                            </FieldLabel>
-                            <div
-                              className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                <ForwardRef
+                                  id="approverLastName"
+                                  invalid={false}
+                                  labelText="Sukunimi *"
+                                  name="approverLastName"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  value="Vanhempi"
+                                >
+                                  <InputWrapper
+                                    className=""
+                                    id="approverLastName"
+                                    invalid={false}
+                                    labelText="Sukunimi *"
+                                  >
+                                    <div
+                                      className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6"
+                                    >
+                                      <FieldLabel
+                                        hidden={false}
+                                        inputId="approverLastName"
+                                        label="Sukunimi *"
+                                        required={false}
+                                      >
+                                        <label
+                                          className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
+                                          htmlFor="approverLastName"
+                                        >
+                                          Sukunimi *
+                                        </label>
+                                      </FieldLabel>
+                                      <div
+                                        className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                      >
+                                        <input
+                                          className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
+                                          disabled={false}
+                                          id="approverLastName"
+                                          name="approverLastName"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          type="text"
+                                          value="Vanhempi"
+                                        />
+                                      </div>
+                                    </div>
+                                  </InputWrapper>
+                                </ForwardRef>
+                              </Field>
+                            </FormikTestInput>
+                            <FormikTestInput
+                              id="approverEmail"
+                              labelText="Sähköpostiosoite *"
+                              name="approverEmail"
+                              type="email"
                             >
-                              <input
-                                className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
-                                disabled={false}
-                                id="approverEmail"
+                              <Field
                                 name="approverEmail"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="email"
-                                value="ville.vanhempi@test.fi"
-                              />
-                            </div>
-                          </div>
-                        </InputWrapper>
-                      </ForwardRef>
-                    </Field>
-                    <Field
-                      as={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "render": [Function],
-                        }
-                      }
-                      className="formField"
-                      helperText=""
-                      id="approverPhone"
-                      invalid={0}
-                      labelText="Puhelin"
-                      name="approverPhone"
-                      type="tel"
-                    >
-                      <ForwardRef
-                        className="formField"
-                        helperText=""
-                        id="approverPhone"
-                        invalid={0}
-                        labelText="Puhelin"
-                        name="approverPhone"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        type="tel"
-                        value="05012345567"
-                      >
-                        <InputWrapper
-                          className="formField"
-                          helperText=""
-                          id="approverPhone"
-                          invalid={0}
-                          labelText="Puhelin"
-                        >
-                          <div
-                            className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6 formField"
-                          >
-                            <FieldLabel
-                              hidden={false}
-                              inputId="approverPhone"
-                              label="Puhelin"
-                              required={false}
-                            >
-                              <label
-                                className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-                                htmlFor="approverPhone"
                               >
-                                Puhelin
-                              </label>
-                            </FieldLabel>
-                            <div
-                              className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                <ForwardRef
+                                  id="approverEmail"
+                                  invalid={false}
+                                  labelText="Sähköpostiosoite *"
+                                  name="approverEmail"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  type="email"
+                                  value="ville.vanhempi@test.fi"
+                                >
+                                  <InputWrapper
+                                    className=""
+                                    id="approverEmail"
+                                    invalid={false}
+                                    labelText="Sähköpostiosoite *"
+                                  >
+                                    <div
+                                      className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6"
+                                    >
+                                      <FieldLabel
+                                        hidden={false}
+                                        inputId="approverEmail"
+                                        label="Sähköpostiosoite *"
+                                        required={false}
+                                      >
+                                        <label
+                                          className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
+                                          htmlFor="approverEmail"
+                                        >
+                                          Sähköpostiosoite *
+                                        </label>
+                                      </FieldLabel>
+                                      <div
+                                        className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                      >
+                                        <input
+                                          className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
+                                          disabled={false}
+                                          id="approverEmail"
+                                          name="approverEmail"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          type="email"
+                                          value="ville.vanhempi@test.fi"
+                                        />
+                                      </div>
+                                    </div>
+                                  </InputWrapper>
+                                </ForwardRef>
+                              </Field>
+                            </FormikTestInput>
+                            <FormikTestInput
+                              id="approverPhone"
+                              labelText="Puhelinnumero *"
+                              name="approverPhone"
+                              type="tel"
                             >
-                              <input
-                                className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
-                                disabled={false}
-                                id="approverPhone"
+                              <Field
                                 name="approverPhone"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="tel"
-                                value="05012345567"
-                              />
-                            </div>
+                              >
+                                <ForwardRef
+                                  id="approverPhone"
+                                  invalid={false}
+                                  labelText="Puhelinnumero *"
+                                  name="approverPhone"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  type="tel"
+                                  value="05012345567"
+                                >
+                                  <InputWrapper
+                                    className=""
+                                    id="approverPhone"
+                                    invalid={false}
+                                    labelText="Puhelinnumero *"
+                                  >
+                                    <div
+                                      className="TextInput-module_root__1ceal text-input_hds-text-input__24bl6"
+                                    >
+                                      <FieldLabel
+                                        hidden={false}
+                                        inputId="approverPhone"
+                                        label="Puhelinnumero *"
+                                        required={false}
+                                      >
+                                        <label
+                                          className="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
+                                          htmlFor="approverPhone"
+                                        >
+                                          Puhelinnumero *
+                                        </label>
+                                      </FieldLabel>
+                                      <div
+                                        className="TextInput-module_inputWrapper__1ru3h text-input_hds-text-input__input-wrapper__2p7Uy"
+                                      >
+                                        <input
+                                          className="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
+                                          disabled={false}
+                                          id="approverPhone"
+                                          name="approverPhone"
+                                          onBlur={[Function]}
+                                          onChange={[Function]}
+                                          type="tel"
+                                          value="05012345567"
+                                        />
+                                      </div>
+                                    </div>
+                                  </InputWrapper>
+                                </ForwardRef>
+                              </Field>
+                            </FormikTestInput>
                           </div>
-                        </InputWrapper>
-                      </ForwardRef>
-                    </Field>
-                  </div>
+                        </YouthProfileFormGrid>
+                        <ArrayFieldTemplate
+                          addItemLabel="Lisää toisen huoltajan yhteystiedot"
+                          name="additionalContactPersons"
+                          onPushItem={[Function]}
+                          renderField={[Function]}
+                        >
+                          <FormikConnect(FieldArrayInner)
+                            name="additionalContactPersons"
+                            render={[Function]}
+                          >
+                            <FieldArrayInner
+                              formik={
+                                Object {
+                                  "dirty": false,
+                                  "errors": Object {},
+                                  "getFieldMeta": [Function],
+                                  "getFieldProps": [Function],
+                                  "handleBlur": [Function],
+                                  "handleChange": [Function],
+                                  "handleReset": [Function],
+                                  "handleSubmit": [Function],
+                                  "initialErrors": Object {},
+                                  "initialStatus": undefined,
+                                  "initialTouched": Object {},
+                                  "initialValues": Object {
+                                    "additionalContactPersons": Array [],
+                                    "address": "Testikuja 55, 00100 Helsinki",
+                                    "addresses": Array [
+                                      "Kymintie 43, 00100 Helsinki",
+                                    ],
+                                    "approverEmail": "ville.vanhempi@test.fi",
+                                    "approverFirstName": "Ville",
+                                    "approverLastName": "Vanhempi",
+                                    "approverPhone": "05012345567",
+                                    "birthDate": "2006-01-01",
+                                    "email": "teemu.testaaja@test.fi",
+                                    "firstName": "Teemu",
+                                    "language": "FINNISH",
+                                    "languageAtHome": "FINNISH",
+                                    "lastName": "Testaaja",
+                                    "phone": "050123467",
+                                    "photoUsageApproved": "false",
+                                    "schoolClass": "Luokka",
+                                    "schoolName": "Koulu",
+                                    "terms": false,
+                                  },
+                                  "isSubmitting": false,
+                                  "isValid": true,
+                                  "isValidating": false,
+                                  "registerField": [Function],
+                                  "resetForm": [Function],
+                                  "setErrors": [Function],
+                                  "setFieldError": [Function],
+                                  "setFieldTouched": [Function],
+                                  "setFieldValue": [Function],
+                                  "setFormikState": [Function],
+                                  "setStatus": [Function],
+                                  "setSubmitting": [Function],
+                                  "setTouched": [Function],
+                                  "setValues": [Function],
+                                  "status": undefined,
+                                  "submitCount": 0,
+                                  "submitForm": [Function],
+                                  "touched": Object {},
+                                  "unregisterField": [Function],
+                                  "validateField": [Function],
+                                  "validateForm": [Function],
+                                  "validateOnBlur": true,
+                                  "validateOnChange": true,
+                                  "validateOnMount": false,
+                                  "values": Object {
+                                    "additionalContactPersons": Array [],
+                                    "address": "Testikuja 55, 00100 Helsinki",
+                                    "addresses": Array [
+                                      "Kymintie 43, 00100 Helsinki",
+                                    ],
+                                    "approverEmail": "ville.vanhempi@test.fi",
+                                    "approverFirstName": "Ville",
+                                    "approverLastName": "Vanhempi",
+                                    "approverPhone": "05012345567",
+                                    "birthDate": "2006-01-01",
+                                    "email": "teemu.testaaja@test.fi",
+                                    "firstName": "Teemu",
+                                    "language": "FINNISH",
+                                    "languageAtHome": "FINNISH",
+                                    "lastName": "Testaaja",
+                                    "phone": "050123467",
+                                    "photoUsageApproved": "false",
+                                    "schoolClass": "Luokka",
+                                    "schoolName": "Koulu",
+                                    "terms": false,
+                                  },
+                                }
+                              }
+                              name="additionalContactPersons"
+                              render={[Function]}
+                              validateOnChange={true}
+                            >
+                              <Stack
+                                space="m"
+                              >
+                                <div
+                                  className="stack m"
+                                >
+                                  <ForwardRef
+                                    className="addItemButton"
+                                    iconLeft={<IconPlusCircle />}
+                                    onClick={[Function]}
+                                    type="button"
+                                    variant="supplementary"
+                                  >
+                                    <button
+                                      className="Button-module_button__3wgee button_hds-button__2A0je Button-module_supplementary__3Epn- button_hds-button--supplementary__GcHcV addItemButton"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <div
+                                        aria-hidden="true"
+                                        className="Button-module_icon__3Wlc6 button_hds-icon__17j8Z"
+                                      >
+                                        <IconPlusCircle>
+                                          <svg
+                                            className="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                            style={Object {}}
+                                            viewBox="0 0 24 24"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <g
+                                              fill="none"
+                                              fillRule="evenodd"
+                                            >
+                                              <path
+                                                d="M0 0h24v24H0z"
+                                              />
+                                              <path
+                                                d="M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2zm0 2a8 8 0 100 16 8 8 0 000-16zm1 3v4h4v2h-4v4h-2v-4H7v-2h4V7h2z"
+                                                fill="currentColor"
+                                              />
+                                            </g>
+                                          </svg>
+                                        </IconPlusCircle>
+                                      </div>
+                                      <span
+                                        className="Button-module_label__2zMLC button_hds-button__label__2EQa-"
+                                      >
+                                        Lisää toisen huoltajan yhteystiedot
+                                      </span>
+                                    </button>
+                                  </ForwardRef>
+                                </div>
+                              </Stack>
+                            </FieldArrayInner>
+                          </FormikConnect(FieldArrayInner)>
+                        </ArrayFieldTemplate>
+                      </div>
+                    </Stack>
+                  </YouthProfileApproverFields>
                 </div>
                 <TermsField
                   id="terms"

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -424,13 +424,13 @@ exports[`matches snapshot 1`] = `
       >
         <div>
           <Text
-            variant="h2"
+            variant="h1"
           >
-            <h2
-              className="text h2 "
+            <h1
+              className="text h1 "
             >
               Hyväksy jäsenyys
-            </h2>
+            </h1>
           </Text>
           <Text
             variant="info"
@@ -450,13 +450,13 @@ exports[`matches snapshot 1`] = `
         </div>
         <div>
           <Text
-            variant="h3"
+            variant="h2"
           >
-            <h3
-              className="text h3 "
+            <h2
+              className="text h2 "
             >
               Perustiedot
-            </h3>
+            </h2>
           </Text>
           <BasicInformationGrid
             addresses={
@@ -629,13 +629,13 @@ exports[`matches snapshot 1`] = `
         </div>
         <div>
           <Text
-            variant="h3"
+            variant="h2"
           >
-            <h3
-              className="text h3 "
+            <h2
+              className="text h2 "
             >
               Lisätiedot
-            </h3>
+            </h2>
           </Text>
           <InfoGrid>
             <div
@@ -698,22 +698,22 @@ exports[`matches snapshot 1`] = `
               >
                 <div>
                   <Text
+                    variant="h2"
+                  >
+                    <h2
+                      className="text h2 "
+                    >
+                      Huoltajalta vaadittavat luvat
+                    </h2>
+                  </Text>
+                  <Text
                     variant="h3"
                   >
                     <h3
                       className="text h3 "
                     >
-                      Huoltajalta vaadittavat luvat
-                    </h3>
-                  </Text>
-                  <Text
-                    variant="h4"
-                  >
-                    <h4
-                      className="text h4 "
-                    >
                       Kuvauslupa
-                    </h4>
+                    </h3>
                   </Text>
                   <Text
                     variant="info"
@@ -835,13 +835,13 @@ exports[`matches snapshot 1`] = `
                 </div>
                 <div>
                   <Text
-                    variant="h3"
+                    variant="h2"
                   >
-                    <h3
-                      className="text h3 "
+                    <h2
+                      className="text h2 "
                     >
                       Huoltajan tiedot
-                    </h3>
+                    </h2>
                   </Text>
                   <Text
                     variant="info"

--- a/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
@@ -3,15 +3,16 @@ import { useTranslation } from 'react-i18next';
 
 import ArrayFieldTemplate from '../../../common/components/arrayFieldTemplate/ArrayFieldTemplate';
 import Stack from '../../../common/components/stack/Stack';
-import ageConstants from '../constants/ageConstants';
 import YouthProfileFormGrid from './YouthProfileFormGrid';
 import TextInput from './FormikTextInput';
 
 type Props = {
-  youthAge: number;
+  isApproverFieldsRequired?: boolean;
 };
 
-function YouthProfileApproverFields({ youthAge }: Props) {
+function YouthProfileApproverFields({
+  isApproverFieldsRequired = true,
+}: Props) {
   const { t } = useTranslation();
 
   // For now when using .when() in validation we can't use
@@ -19,9 +20,12 @@ function YouthProfileApproverFields({ youthAge }: Props) {
   // Validation rules returned from .when() won't be added there.
   // For this reason determining asterisk usage must
   // be done with this function
-  const approverLabelText = (name: string) => {
-    if (youthAge < ageConstants.ADULT) return t(`registration.${name}`) + ' *';
-    return t(`registration.${name}`);
+  const labelRequired = (translationPath: string) => {
+    if (isApproverFieldsRequired) {
+      return t(translationPath) + ' *';
+    }
+
+    return t(translationPath);
   };
 
   return (
@@ -30,24 +34,24 @@ function YouthProfileApproverFields({ youthAge }: Props) {
         <TextInput
           id="approverFirstName"
           name="approverFirstName"
-          labelText={approverLabelText('firstName')}
+          labelText={labelRequired('registration.firstName')}
         />
         <TextInput
           id="approverLastName"
           name="approverLastName"
-          labelText={approverLabelText('lastName')}
+          labelText={labelRequired('registration.lastName')}
         />
         <TextInput
           id="approverEmail"
           name="approverEmail"
           type="email"
-          labelText={approverLabelText('email')}
+          labelText={labelRequired('registration.email')}
         />
         <TextInput
           id="approverPhone"
           name="approverPhone"
           type="tel"
-          labelText={approverLabelText('phoneNumber')}
+          labelText={labelRequired('registration.phoneNumber')}
         />
       </YouthProfileFormGrid>
       <ArrayFieldTemplate
@@ -57,24 +61,24 @@ function YouthProfileApproverFields({ youthAge }: Props) {
             <TextInput
               id={`${arrayPath}.firstName`}
               name={`${arrayPath}.firstName`}
-              labelText={approverLabelText('firstName')}
+              labelText={t('registration.firstName') + ' *'}
             />
             <TextInput
               id={`${arrayPath}.lastName`}
               name={`${arrayPath}.lastName`}
-              labelText={approverLabelText('lastName')}
+              labelText={t('registration.lastName') + ' *'}
             />
             <TextInput
               id={`${arrayPath}.email`}
               name={`${arrayPath}.email`}
               type="email"
-              labelText={approverLabelText('email')}
+              labelText={t('registration.email') + ' *'}
             />
             <TextInput
               id={`${arrayPath}.phone`}
               name={`${arrayPath}.phone`}
               type="tel"
-              labelText={approverLabelText('phoneNumber')}
+              labelText={t('registration.phoneNumber') + ' *'}
             />
           </YouthProfileFormGrid>
         )}

--- a/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
@@ -3,15 +3,26 @@ import { useTranslation } from 'react-i18next';
 
 import ArrayFieldTemplate from '../../../common/components/arrayFieldTemplate/ArrayFieldTemplate';
 import Stack from '../../../common/components/stack/Stack';
+import ageConstants from '../constants/ageConstants';
 import YouthProfileFormGrid from './YouthProfileFormGrid';
 import TextInput from './FormikTextInput';
 
-interface Props {
-  approverLabelText: (name: string) => string;
-}
+type Props = {
+  youthAge: number;
+};
 
-function YouthProfileApproverFields({ approverLabelText }: Props) {
+function YouthProfileApproverFields({ youthAge }: Props) {
   const { t } = useTranslation();
+
+  // For now when using .when() in validation we can't use
+  // schema.describe().fields[name].tests to determine if field is required or not.
+  // Validation rules returned from .when() won't be added there.
+  // For this reason determining asterisk usage must
+  // be done with this function
+  const approverLabelText = (name: string) => {
+    if (youthAge < ageConstants.ADULT) return t(`registration.${name}`) + ' *';
+    return t(`registration.${name}`);
+  };
 
   return (
     <Stack space="xl">

--- a/src/domain/youthProfile/form/YouthProfileForm.tsx
+++ b/src/domain/youthProfile/form/YouthProfileForm.tsx
@@ -70,16 +70,6 @@ function YouthProfileForm(componentProps: Props) {
     new Date(componentProps.profile.birthDate)
   );
 
-  // For now when using .when() in validation we can't use
-  // schema.describe().fields[name].tests to determine if field is required or not.
-  // Validation rules returned from .when() won't be added there.
-  // For this reason determining asterisk usage must
-  // be done with this function
-  const approverLabelText = (name: string) => {
-    if (userAge < ageConstants.ADULT) return t(`registration.${name}`) + ' *';
-    return t(`registration.${name}`);
-  };
-
   return (
     <Formik
       validateOnBlur={true}
@@ -141,9 +131,7 @@ function YouthProfileForm(componentProps: Props) {
                   : t('registration.approverInfoOver18Text')}
               </Text>
 
-              <YouthProfileApproverFields
-                approverLabelText={approverLabelText}
-              />
+              <YouthProfileApproverFields youthAge={userAge} />
             </PageSection>
             <PageSection>
               {!componentProps.isEditing && (

--- a/src/domain/youthProfile/form/YouthProfileForm.tsx
+++ b/src/domain/youthProfile/form/YouthProfileForm.tsx
@@ -21,7 +21,7 @@ import Text from '../../../common/components/text/Text';
 import Stack from '../../../common/components/stack/Stack';
 import TermsField from '../../../common/components/termsField/TermsField';
 import ageConstants from '../constants/ageConstants';
-import youthProfileFormSchema from './youthProfileFormSchema';
+import { youthProfileFormSchema } from '../youthProfileSchemas';
 import YouthProfileBasicInformationFields from './YouthProfileBasicInformationFields';
 import YouthProfileAdditionalInformationFields from './YouthProfileAdditionalInformationFields';
 import YouthProfileApproverFields from './YouthProfileApproverFields';
@@ -131,7 +131,9 @@ function YouthProfileForm(componentProps: Props) {
                   : t('registration.approverInfoOver18Text')}
               </Text>
 
-              <YouthProfileApproverFields youthAge={userAge} />
+              <YouthProfileApproverFields
+                isApproverFieldsRequired={userAge < ageConstants.ADULT}
+              />
             </PageSection>
             <PageSection>
               {!componentProps.isEditing && (

--- a/src/domain/youthProfile/youthProfileSchemas.ts
+++ b/src/domain/youthProfile/youthProfileSchemas.ts
@@ -5,7 +5,7 @@ import {
   postcodeValidatorExistsForCountry,
 } from 'postcode-validator';
 
-import ageConstants from '../constants/ageConstants';
+import ageConstants from './constants/ageConstants';
 
 const isConsentRequired = (birthDate: string, schema: Yup.StringSchema) => {
   const userAge = differenceInYears(new Date(), new Date(birthDate));
@@ -14,7 +14,33 @@ const isConsentRequired = (birthDate: string, schema: Yup.StringSchema) => {
     : schema;
 };
 
-const schema = Yup.object().shape({
+const requireIfNotAdult = (extendedSchema: Yup.StringSchema) => {
+  return extendedSchema.when(
+    ['birthDate'],
+    (birthDate: string, schema: Yup.StringSchema) =>
+      isConsentRequired(birthDate, schema)
+  );
+};
+
+const approverFirstNameSchema = Yup.string()
+  .min(2, 'validation.tooShort')
+  .max(255, 'validation.tooLong');
+const approverLastNameSchema = Yup.string()
+  .min(2, 'validation.tooShort')
+  .max(255, 'validation.tooLong');
+const approverEmailSchema = Yup.string().email('validation.email');
+const approverPhoneSchema = Yup.string().min(6, 'validation.phoneMin');
+
+const additionalContactPersonsSchema = Yup.array(
+  Yup.object({
+    firstName: Yup.string().required('validation.required'),
+    lastName: Yup.string().required('validation.required'),
+    phone: Yup.string().required('validation.required'),
+    email: Yup.string().required('validation.required'),
+  })
+);
+
+const basicInformationSchema = Yup.object().shape({
   firstName: Yup.string()
     .min(2, 'validation.tooShort')
     .max(255, 'validation.tooLong')
@@ -70,40 +96,39 @@ const schema = Yup.object().shape({
   phone: Yup.string()
     .min(6, 'validation.phoneMin')
     .required('validation.required'),
-  schoolName: Yup.string().max(128, 'validation.tooLong'),
-  schoolClass: Yup.string().max(10, 'validation.tooLong'),
-  approverFirstName: Yup.string()
-    .min(2, 'validation.tooShort')
-    .max(255, 'validation.tooLong')
-    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
-      isConsentRequired(birthDate, schema)
-    ),
-  approverLastName: Yup.string()
-    .min(2, 'validation.tooShort')
-    .max(255, 'validation.tooLong')
-    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
-      isConsentRequired(birthDate, schema)
-    ),
-  approverPhone: Yup.string()
-    .min(6, 'validation.phoneMin')
-    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
-      isConsentRequired(birthDate, schema)
-    ),
-  approverEmail: Yup.string()
-    .email('validation.email')
-    .when(['birthDate'], (birthDate: string, schema: Yup.StringSchema) =>
-      isConsentRequired(birthDate, schema)
-    ),
-  photoUsageApproved: Yup.string().required('validation.required'),
-  terms: Yup.boolean().oneOf([true], 'validation.required'),
-  additionalContactPersons: Yup.array(
-    Yup.object({
-      firstName: Yup.string().required('validation.required'),
-      lastName: Yup.string().required('validation.required'),
-      phone: Yup.string().required('validation.required'),
-      email: Yup.string().required('validation.required'),
-    })
-  ),
 });
 
-export default schema;
+const additionalInformationSchema = Yup.object().shape({
+  schoolName: Yup.string().max(128, 'validation.tooLong'),
+  schoolClass: Yup.string().max(10, 'validation.tooLong'),
+  photoUsageApproved: Yup.string().required('validation.required'),
+});
+
+const youthApproverSchema = Yup.object().shape({
+  approverFirstName: requireIfNotAdult(approverFirstNameSchema),
+  approverLastName: requireIfNotAdult(approverLastNameSchema),
+  approverPhone: requireIfNotAdult(approverPhoneSchema),
+  approverEmail: requireIfNotAdult(approverEmailSchema),
+  additionalContactPersons: additionalContactPersonsSchema,
+});
+
+const guardianApproverSchema = Yup.object().shape({
+  approverFirstName: approverFirstNameSchema.required('validation.required'),
+  approverLastName: approverLastNameSchema.required('validation.required'),
+  approverEmail: approverEmailSchema.required('validation.required'),
+  phone: approverPhoneSchema.required('validation.required'),
+  additionalContactPersons: additionalContactPersonsSchema,
+});
+
+const termsSchema = Yup.object().shape({
+  terms: Yup.boolean().oneOf([true], 'validation.required'),
+});
+
+export const approveYouthProfileFormSchema = guardianApproverSchema.concat(
+  termsSchema
+);
+
+export const youthProfileFormSchema = basicInformationSchema
+  .concat(additionalInformationSchema)
+  .concat(youthApproverSchema)
+  .concat(termsSchema);


### PR DESCRIPTION
These changes add additional contact persons into the approval form. The approver is now able to add, remove or edit additional contact persons.

I refactored the code to be able to use the same field definitions as in `youthProfile/form/YouthProfileApproverFields.tsx`.

I also moved the schemas from `youthProfile/form/youthProfileFormSchemas.ts` into `youthProfile/youthProfileSchemas.ts` and used those definitions in the approve form.