### PR TITLE
YM-332 | Hide user menu and disable links in approval view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Approvers can now control additional contact persons
 
+### Changed
+- Hide user menu and disable links to home page on approval form
+
 ## [1.0.1] - 2020-08-31
 ### Fixed
 - Fixed issue where application would crash when entering `Profile information` page.

--- a/src/common/components/layout/PageLayout.tsx
+++ b/src/common/components/layout/PageLayout.tsx
@@ -1,20 +1,21 @@
 import React, { ReactNode } from 'react';
 
-import Header from './header/Header';
+import Header, { HeaderVariant } from './header/Header';
 import Footer from './footer/Footer';
 import PageWrapper from '../wrapper/PageWrapper';
 import styles from './PageLayout.module.css';
 
 type Props = {
   children: ReactNode;
+  variant?: HeaderVariant;
 };
 
-function PageLayout({ children }: Props) {
+function PageLayout({ children, variant }: Props) {
   return (
     <PageWrapper>
       <div className={styles.layout}>
         <div className={styles.background} />
-        <Header />
+        <Header variant={variant} />
         {children}
         <Footer />
       </div>

--- a/src/common/components/layout/header/Header.tsx
+++ b/src/common/components/layout/header/Header.tsx
@@ -8,22 +8,40 @@ import FullscreenNavigation from '../../fullscreenNavigation/FullscreenNavigatio
 import HelsinkiLogo from '../../helsinkiLogo/HelsinkiLogo';
 import UserDropdown from './userDropdown/UserDropdown';
 
-type Props = {};
+// Approver variant is shown for approver view. The approver should not
+// be shown the user menu, nor should the header contain links for
+// navigating into te front page.
+export type HeaderVariant = 'default' | 'approver';
 
-function Header(props: Props) {
+type Props = {
+  variant?: HeaderVariant;
+};
+
+function Header({ variant = 'default' }: Props) {
   const { t } = useTranslation();
+  const isDefaultVariant = variant === 'default';
+  const isApproverVariant = variant === 'approver';
+
   return (
     <header className={styles.header}>
       <div className={styles.content}>
-        <HelsinkiLogo className={styles.logo} isLinkToFrontPage />
-        <Link to="/" className={styles.appName}>
-          {t('appName')}
-        </Link>
+        <HelsinkiLogo
+          className={styles.logo}
+          isLinkToFrontPage={isDefaultVariant}
+        />
+        {isDefaultVariant && (
+          <Link to="/" className={styles.appName}>
+            {t('appName')}
+          </Link>
+        )}
+        {isApproverVariant && (
+          <span className={styles.appName}>{t('appName')}</span>
+        )}
         <section className={styles.end}>
           <FullscreenNavigation className={styles.mobileNav} />
           <div className={styles.desktopNav}>
             <LanguageSwitcher />
-            <UserDropdown />
+            {isDefaultVariant && <UserDropdown />}
           </div>
         </section>
       </div>

--- a/src/domain/app/AppRoutes.tsx
+++ b/src/domain/app/AppRoutes.tsx
@@ -16,38 +16,52 @@ import NotFoundPage from '../notFoundPage/NotFoundPage';
 
 function AppRoutes() {
   return (
-    <PageLayout>
-      <Switch>
-        <Route path="/login" exact component={Login} />
-        <AppYouthProfileRoute path="/" exact component={LandingPage} />
-        <AppYouthProfileRoute
-          path="/membership-details"
-          exact
-          component={MembershipDetailsPage}
-        />
-        <AppYouthProfileRoute
-          path="/edit"
-          exact
-          component={EditYouthProfilePage}
-        />
-        <Route path="/create" exact component={CreateYouthProfilePage} />
-        <Route
-          path="/approve/:token"
-          exact
-          component={ApproveYouthProfilePage}
-        />
-        <Route path="/accessibility" exact component={AccessibilityStatement} />
-        <Route
-          path="/silent_renew"
-          render={() => {
-            userManager.signinSilentCallback();
-            return null;
-          }}
-        />
-        <Route path="/callback" component={OidcCallback} />
-        <Route path="*" component={NotFoundPage} />
-      </Switch>
-    </PageLayout>
+    <Switch>
+      <Route path={['/approve/:token']}>
+        <PageLayout variant="approver">
+          <Switch>
+            <Route
+              path="/approve/:token"
+              exact
+              component={ApproveYouthProfilePage}
+            />
+          </Switch>
+        </PageLayout>
+      </Route>
+      <Route>
+        <PageLayout>
+          <Switch>
+            <Route path="/login" exact component={Login} />
+            <AppYouthProfileRoute path="/" exact component={LandingPage} />
+            <AppYouthProfileRoute
+              path="/membership-details"
+              exact
+              component={MembershipDetailsPage}
+            />
+            <AppYouthProfileRoute
+              path="/edit"
+              exact
+              component={EditYouthProfilePage}
+            />
+            <Route path="/create" exact component={CreateYouthProfilePage} />
+            <Route
+              path="/accessibility"
+              exact
+              component={AccessibilityStatement}
+            />
+            <Route
+              path="/silent_renew"
+              render={() => {
+                userManager.signinSilentCallback();
+                return null;
+              }}
+            />
+            <Route path="/callback" component={OidcCallback} />
+            <Route path="*" component={NotFoundPage} />
+          </Switch>
+        </PageLayout>
+      </Route>
+    </Switch>
   );
 }
 


### PR DESCRIPTION
After this change the header in the approval view should no longer have a user menu and the logo nor the name of the service should link the user to the home page.

I ended up adopting the following pattern

```jsx
    <Switch>
      <Route path={['/approve/:token']}>
        <PageLayout variant="approver">
          <Switch>
            {/* Routes... */}
          </Switch>
        </PageLayout>
      </Route>
      <Route>
        <PageLayout>
          <Switch>
            {/* Routes... */}
          </Switch>
        </PageLayout>
      </Route>
    </Switch>
```

In my opinion this is a bit ugly. I'm trying to do two things at the same time which it appears are not that easy to do at the same time: (a) have composable layouts that (b) can be shared between routes.

Why? I want _a_ because without it the architecture is forced to adopt an "extend" approach where logic is added to existing components. Those kind of component will become hard to maintain and reuse. Instead I think that it's better to try and increase composability--it's easier to maintain and it'll be easier to share logic.

I want _b_ because I want to avoid re-rendering shared page element on every page change. In a regular web application this is a given--the whole document is loaded when a page is changed so this behaviour is not a concern. However, with SPAs we can avoid doing this and instead only re-render the content that is changed when the user navigates. If every page is declared with a new instance of `<PageLayout />`, at least some overhead is added. This can manifest as flickering and other visual quirks that make the application seem less robust. To be fair, I suspect that the optimisation React does help with this particular problem and I have an inkling that _b_ is nowhere near as important as _a_.

Note that within these changes I have already extended the `<Header />`. My personal view here is that re-thinking the `<Header />` is too much work for this PR considering, that the new navigation component in HDS has already launched. But, the choices I've made, in my opinion, introduce no new obstacles for creating a composable header in the future.