### PR TITLE
YM-352 | Improve authentication callback error handling

### DIFF
--- a/src/common/components/layout/InfoPageLayout.tsx
+++ b/src/common/components/layout/InfoPageLayout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import Text from '../text/Text';
+import PageSection from './PageSection';
+import PageContent from './PageContent';
+import styles from './infoPageLayout.module.css';
+
+type Props = {
+  title: string;
+  description: string;
+};
+
+const InfoPageLayout = ({ title, description }: Props) => {
+  return (
+    <PageContent>
+      <PageSection className={styles.centerText}>
+        <Text variant="h1">{title}</Text>
+        <Text variant="info">{description}</Text>
+      </PageSection>
+    </PageContent>
+  );
+};
+
+export default InfoPageLayout;

--- a/src/common/components/layout/PageContent.tsx
+++ b/src/common/components/layout/PageContent.tsx
@@ -40,7 +40,7 @@ function PageContent({
 
   return (
     <LoadingContent isLoading={!isReady} loadingText={loadingText}>
-      <div className={styles.wrapper}>{children}</div>
+      <main className={styles.wrapper}>{children}</main>
     </LoadingContent>
   );
 }

--- a/src/common/components/layout/PageSection.tsx
+++ b/src/common/components/layout/PageSection.tsx
@@ -4,10 +4,18 @@ import styles from './pageSection.module.css';
 
 interface Props {
   children: ReactNode;
+  className?: string;
 }
 
-function YouthProfileFormSection(props: Props) {
-  return <div className={styles.pageSection} {...props} />;
+function YouthProfileFormSection({
+  className: additionalClassName,
+  ...rest
+}: Props) {
+  const className = [styles.pageSection, additionalClassName]
+    .filter(item => item)
+    .join(' ');
+
+  return <div className={className} {...rest} />;
 }
 
 export default YouthProfileFormSection;

--- a/src/common/components/layout/infoPageLayout.module.css
+++ b/src/common/components/layout/infoPageLayout.module.css
@@ -1,0 +1,3 @@
+.centerText {
+  text-align: center;
+}

--- a/src/domain/auth/components/oidcCallback/OidcCallback.tsx
+++ b/src/domain/auth/components/oidcCallback/OidcCallback.tsx
@@ -1,31 +1,90 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CallbackComponent } from 'redux-oidc';
-import { useHistory } from 'react-router';
+import { RouteChildrenProps } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/browser';
 
+import InfoPageLayout from '../../../../common/components/layout/InfoPageLayout';
 import LoadingContent from '../../../../common/components/loading/LoadingContent';
 import userManager from '../../userManager';
 
-type Props = {};
+type AuthenticationError =
+  | 'deviceTimeError'
+  | 'permissionDeniedByUserError'
+  | 'unknown';
 
-function OidcCallback(props: Props) {
-  const history = useHistory();
-  const onSuccess = (user: object) => {
-    history.push('/');
-  };
-  const onError = (error: object) => {
-    Sentry.captureException(error);
-    history.push('/');
-  };
+// eslint-disable-next-line max-len
+// https://github.com/City-of-Helsinki/kukkuu-ui/blob/0c708490d8202ff9828a76f2bc5b9c59bce76550/src/domain/auth/OidcCallback.tsx
+function OidcCallback({ history }: RouteChildrenProps) {
   const { t } = useTranslation();
+  const [
+    authenticationError,
+    setAuthenticationError,
+  ] = useState<AuthenticationError | null>(null);
+
+  const onSuccess = () => {
+    // Use replace in order to hide the callback view from history.
+    history.replace('/');
+  };
+
+  const onError = (error: Error) => {
+    // Handle error caused by device time being more than 5 minutes off:
+    if (
+      error.message.includes('iat is in the future') ||
+      error.message.includes('exp is in the past')
+    ) {
+      setAuthenticationError('deviceTimeError');
+    } else if (
+      // Handle error caused by end user choosing Deny in Tunnistamo's
+      // permission request
+      error.message ===
+      'The resource owner or authorization server denied the request'
+    ) {
+      setAuthenticationError('permissionDeniedByUserError');
+    } else {
+      // Send other errors to Sentry for analysis
+      Sentry.captureException(error);
+      // Give user a generic error
+      setAuthenticationError('unknown');
+    }
+  };
+
+  const isLoading = !authenticationError;
+  const isDeviceTimeError = authenticationError === 'deviceTimeError';
+  const isPermissionDeniedByUserError =
+    authenticationError === 'permissionDeniedByUserError';
+  const isUnknownError = authenticationError === 'unknown';
+
   return (
     <CallbackComponent
       successCallback={onSuccess}
       errorCallback={onError}
       userManager={userManager}
     >
-      <LoadingContent isLoading={true} loadingText={t('oidc.authenticating')} />
+      <>
+        <LoadingContent
+          isLoading={isLoading}
+          loadingText={t('oidc.authenticating')}
+        />
+        {isDeviceTimeError && (
+          <InfoPageLayout
+            title={t('authentication.errorTitle')}
+            description={t('authentication.deviceTimeError.message')}
+          />
+        )}
+        {isPermissionDeniedByUserError && (
+          <InfoPageLayout
+            title={t('authentication.errorTitle')}
+            description={t('authentication.permRequestDenied.message')}
+          />
+        )}
+        {isUnknownError && (
+          <InfoPageLayout
+            title={t('authentication.errorTitle')}
+            description={t('authentication.errorMessage')}
+          />
+        )}
+      </>
     </CallbackComponent>
   );
 }

--- a/src/domain/youthProfile/approve/__test__/ApproveYouthProfilePage.test.tsx
+++ b/src/domain/youthProfile/approve/__test__/ApproveYouthProfilePage.test.tsx
@@ -97,7 +97,7 @@ test('there is no user data / profile has already been approved', async () => {
 
   await updateWrapper(wrapper);
 
-  const content = wrapper.find('div[className="wrapper"]');
+  const content = wrapper.find('main[className="wrapper"]');
   const title = content.find('h2');
 
   expect(title.text()).toEqual('Hakemus on jo hyväksytty ');

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,6 +31,16 @@
     "schoolInfo": "School and class",
     "title": "Please approve membership"
   },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "permRequestDenied": {
+      "message": "You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    },
+    "errorTitle": "Oops!",
+    "errorMessage": "An error occured while logging in. Please try again"
+  },
   "confirmSendingProfile": {
     "buttonText": "Resend the membership request",
     "helpText": "Your membership application has been sent to",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -33,10 +33,10 @@
   },
   "authentication": {
     "deviceTimeError": {
-      "message": "Usko tai älä usko mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan."
+      "message": "Usko tai älä usko, mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan."
     },
     "permRequestDenied": {
-      "message": "You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+      "message": "Sinun täytyy hyväksyä pyytämämme oikeudet Tunnistamossa käyttääksesi tätä palvelua. Ole hyvä ja yritä kirjautua uudelleen."
     },
     "errorTitle": "Hupsista!",
     "errorMessage": "Tapahtui virhe. Yritä uudestaan"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -31,6 +31,16 @@
     "schoolInfo": "Koulu ja luokka",
     "title": "Hyväksy jäsenyys"
   },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Usko tai älä usko mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan."
+    },
+    "permRequestDenied": {
+      "message": "You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    },
+    "errorTitle": "Hupsista!",
+    "errorMessage": "Tapahtui virhe. Yritä uudestaan"
+  },
   "confirmSendingProfile": {
     "buttonText": "Lähetä uusi varmistusviesti",
     "helpText": "Olet lähettänyt jäsenyyden hyväksyttäväksi osoitteeseen",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -31,6 +31,16 @@
     "schoolInfo": "Skola och klass",
     "title": "Godkänn medlemskapet"
   },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "Tro det eller ej, men du kan inte logga in eftersom din enhets klocka går mer än 5 minuter fel. Justera klockan och försök igen."
+    },
+    "permRequestDenied": {
+      "message": "Du måste godkänna begäran om åtkomst till din Tunnistamo-profil för att kunna använda den här tjänsten. Försök att logga in igen."
+    },
+    "errorTitle": "Hoppsan!",
+    "errorMessage": "Ett fel uppstod. Försök igen"
+  },
   "confirmSendingProfile": {
     "buttonText": "Skicka ett nytt verifieringsmeddelande",
     "helpText": "Din medlemsansökan har skickats till",


### PR DESCRIPTION
Previously the error handling in the authentication callback didn't handle some known problem cases
* Device time off by more than 5min
* User declines permission

I just copied the logic over from Kukkuu.

The real issue was that the callback used `history.push` when it redirected the user into another view. This left the `/ callback` page into the browser history. We suspect that users sometimes accidentally access this page again when they use the browser's back button to navigate.

I also noticed that we were not using `main` at all, so I added it into the `<PageContent>` component.