### PR TITLE
YM-362 | Fix scroll to first error

### DIFF
--- a/src/domain/youthProfile/form/FormikFocusError.tsx
+++ b/src/domain/youthProfile/form/FormikFocusError.tsx
@@ -19,6 +19,19 @@ const defaultConfig: ScrollConfig = {
   duration: 800,
 };
 
+const FIELD_ORDER = [
+  'firstName',
+  'lastName',
+  'primaryAddress',
+  'phone',
+  'approverFirstName',
+  'approverLastName',
+  'approverEmail',
+  'approverPhone',
+  'additionalContactPersons',
+  'terms',
+];
+
 const getErrorElement = (errors: FormikErrors<FormValues>, key: string) => {
   switch (key) {
     case 'primaryAddress':
@@ -26,10 +39,23 @@ const getErrorElement = (errors: FormikErrors<FormValues>, key: string) => {
       return document.querySelector(`[name="primaryAddress.${primaryKeys[0]}"`);
     case 'addresses':
       const firstIndex = (errors.addresses as []).findIndex(error => error);
-      // postalCode is only validated field in additional addressess
+      // postalCode is only validated field in additional addresses
       return document.querySelector(
         `[name="addresses.${firstIndex}.postalCode"`
       );
+    case 'additionalContactPersons':
+      const firstContactPerson = (errors.additionalContactPersons as object[]).findIndex(
+        error => error
+      );
+      const additionalPersonsKeys: string[] =
+        (errors.additionalContactPersons &&
+          Object.keys(errors.additionalContactPersons[firstContactPerson])) ||
+        [];
+
+      return document.querySelector(
+        `[name="additionalContactPersons.${firstContactPerson}.${additionalPersonsKeys[0]}"]`
+      );
+
     default:
       return document.querySelector(`[name="${key}"`);
   }
@@ -39,8 +65,11 @@ function FormikFocusError() {
   const { errors, isSubmitting, isValidating } = useFormikContext<FormValues>();
   const keys = Object.keys(errors);
 
-  if (keys.length > 0 && isSubmitting && !isValidating) {
-    const errorElement = getErrorElement(errors, keys[0]);
+  // Change the order of the keys to match the order in which the fields appear on the form
+  const sortedKeys = FIELD_ORDER.filter(field => keys.includes(field));
+
+  if (sortedKeys.length > 0 && isSubmitting && !isValidating) {
+    const errorElement = getErrorElement(errors, sortedKeys[0]);
 
     // Scroll only happens when element is out of view.
     if (errorElement && errorElement.getBoundingClientRect().top < 0) {


### PR DESCRIPTION
Scroll to first error was broken. When getting error keys, the order would be pretty much random. I added logic that sorts keys to match the order in which the fields occur in our form. 

Also added scroll handling to `additionalContactPersons`. After #160 is merged, I'll try to write e2e test so the functionality won't break again.