### PR TITLE
YM-362 | Add e2e test for scrolling to first error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Approvers can now control additional contact persons
+- e2e - tests for youth's registration form.
 
 ### Changed
 - Hide user menu and disable links to home page on approval form
+- Replaced Cypress with TestCafe
 
 ## [1.0.1] - 2020-08-31
 ### Fixed

--- a/browser-tests/registrationView.ts
+++ b/browser-tests/registrationView.ts
@@ -16,7 +16,11 @@ test('Test all required fields if user is adult', async t => {
     'div[class^="TextInput-module_helperText"]'
   ).count;
 
-  await t.expect(allRequiredErrors).eql(6);
+  await t
+    .expect(allRequiredErrors)
+    .eql(6)
+    .expect(registrationFormSelector.firstName.focused)
+    .ok();
 });
 
 test('Test all required fields if user is minor', async t => {
@@ -28,7 +32,11 @@ test('Test all required fields if user is minor', async t => {
     'div[class^="TextInput-module_helperText"]'
   ).count;
 
-  await t.expect(allRequiredErrors).eql(10);
+  await t
+    .expect(allRequiredErrors)
+    .eql(10)
+    .expect(registrationFormSelector.firstName.focused)
+    .ok();
 });
 
 test('Fill all form fields', async t => {


### PR DESCRIPTION
 Added `2e2` test for testing "scroll to first error element" functionality. It's added to both "check errors" tests, it will take extra second to execute so I think it should be fine.

I just realised that I haven't remembered to update `CHANGELOG.md`. I included those to this PR as well.