### PR TITLE
YM-354 | Fix range error

### DIFF
--- a/src/domain/app/AppYouthProfileRoute.tsx
+++ b/src/domain/app/AppYouthProfileRoute.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
 import * as Sentry from '@sentry/browser';
 import { useTranslation } from 'react-i18next';
+import { isValid, parseISO } from 'date-fns';
 
 import { HasYouthProfile } from '../../graphql/generatedTypes';
 import getCookie from '../../common/helpers/getCookie';
@@ -28,13 +29,14 @@ function AppYouthProfileRoute(props: Props) {
 
   const isYouthProfileFound = Boolean(data?.myProfile?.youthProfile);
   const birthDate = getCookie('birthDate');
+  const isBirthDateValid = isValid(parseISO(birthDate));
 
   return (
     <>
       <LoadingContent isLoading={loading} loadingText={t('profile.verifying')}>
         {isYouthProfileFound ? (
           <Route {...props} />
-        ) : !birthDate ? (
+        ) : !isBirthDateValid ? (
           <Redirect to="/login" />
         ) : (
           <Redirect to="/create" />

--- a/src/domain/youthProfile/create/CreateYouthProfile.tsx
+++ b/src/domain/youthProfile/create/CreateYouthProfile.tsx
@@ -6,7 +6,7 @@ import { loader } from 'graphql.macro';
 import * as Sentry from '@sentry/browser';
 import { useTranslation } from 'react-i18next';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
-import { useHistory } from 'react-router';
+import { Redirect, useHistory } from 'react-router';
 import { isValid, parseISO } from 'date-fns';
 
 import {
@@ -72,7 +72,6 @@ function CreateYouthProfile({
 
   const birthDate = getCookie('birthDate');
   const isBirthDateValid = isValid(parseISO(birthDate));
-  if (!isBirthDateValid) history.replace('/login');
 
   const connectService = () => {
     // TODO after back end supports editing serviceConnections change enabled from true to false
@@ -157,7 +156,10 @@ function CreateYouthProfile({
     getLanguageCode(i18n.languages[0])
   ) as YouthLanguage;
 
-  if (!isBirthDateValid) return null;
+  if (!isBirthDateValid) {
+    return <Redirect to="/login" />;
+  }
+
   return (
     <div className={styles.form}>
       <YouthProfileForm

--- a/src/domain/youthProfile/create/CreateYouthProfile.tsx
+++ b/src/domain/youthProfile/create/CreateYouthProfile.tsx
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/browser';
 import { useTranslation } from 'react-i18next';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { useHistory } from 'react-router';
+import { isValid, parseISO } from 'date-fns';
 
 import {
   AddServiceConnection as AddServiceConnectionData,
@@ -70,6 +71,8 @@ function CreateYouthProfile({
   >(UPDATE_PROFILE);
 
   const birthDate = getCookie('birthDate');
+  const isBirthDateValid = isValid(parseISO(birthDate));
+  if (!isBirthDateValid) history.replace('/login');
 
   const connectService = () => {
     // TODO after back end supports editing serviceConnections change enabled from true to false
@@ -154,6 +157,7 @@ function CreateYouthProfile({
     getLanguageCode(i18n.languages[0])
   ) as YouthLanguage;
 
+  if (!isBirthDateValid) return null;
   return (
     <div className={styles.form}>
       <YouthProfileForm

--- a/src/domain/youthProfile/create/__tests__/CreateYouthProfilePage.test.tsx
+++ b/src/domain/youthProfile/create/__tests__/CreateYouthProfilePage.test.tsx
@@ -3,6 +3,7 @@ import { MockedResponse } from '@apollo/react-testing';
 import { User } from 'oidc-client';
 import { loader } from 'graphql.macro';
 import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router';
 
 import {
   mountWithApolloProvider,
@@ -99,8 +100,18 @@ const getMocks = (myProfile: MyProfile) => {
 };
 
 const getWrapper = (mocks?: MockedResponse[]) => {
-  return mountWithApolloProvider(<CreateYouthProfilePage />, mocks);
+  return mountWithApolloProvider(
+    <MemoryRouter>
+      <CreateYouthProfilePage />
+    </MemoryRouter>,
+    mocks
+  );
 };
+
+Object.defineProperty(window.document, 'cookie', {
+  writable: true,
+  value: 'birthDate=2005-01-01',
+});
 
 test('renders form with pre-filled values', async () => {
   const wrapper = getWrapper(getMocks({}));


### PR DESCRIPTION
The random `RangeError` was indeed related to invalid date. I added validation, provided by `date-fns`, for all birthDate values. I also tossed extra redirect inside `CreateYouthProfile` component. It seems that logic validating birth date value inside `AppYouthProfileRoute` is only ran when user goes from /login -> (authentication) -> /create. If user refreshes page while /create route is active, it hits the route specified in `AppRoutes` and skips everything else.  

I guess the other solution would be to enforce this more strictly on router level: Move `HasYouthProfile` query to `AppRoutes` and make birth date check there. 

**Testing**
- Input birth date as always.
- Login and be redirected to registration form
- Change `birthDate` cookie value to something that doesn't exists or just simply `-`
- Refresh the page, you should be redirected back to `/login` page