### PR TITLE
YM-376 | GraphQL error: You don't have permission

### DIFF
--- a/src/domain/app/AppYouthProfileRoute.tsx
+++ b/src/domain/app/AppYouthProfileRoute.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router';
 import { useLazyQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
@@ -22,7 +22,6 @@ type Props = RouteProps;
 function AppYouthProfileRoute(props: Props) {
   const { t } = useTranslation();
   const [showNotification, setShowNotification] = useState<boolean>(false);
-  const [profileLoaded, setProfileLoaded] = useState<boolean>(false);
 
   const [loadProfile, { data, loading }] = useLazyQuery<HasYouthProfile>(
     HAS_YOUTH_PROFILE,
@@ -36,10 +35,9 @@ function AppYouthProfileRoute(props: Props) {
 
   const isAuthenticated = useSelector(isAuthenticatedSelector);
 
-  if (isAuthenticated && !profileLoaded) {
-    loadProfile();
-    setProfileLoaded(true);
-  }
+  useEffect(() => {
+    if (isAuthenticated) loadProfile();
+  }, [isAuthenticated, loadProfile]);
 
   const isYouthProfileFound = Boolean(data?.myProfile?.youthProfile);
   const birthDate = getCookie('birthDate');


### PR DESCRIPTION
## Description

Changed `HasYouthProfile` query to use lazy query instead. Query is executed after we make sure user is authenticated.

## Context

When user entered website, it would immediately trigger `HasYouthProfile` query and cause `[GraphQL error]`. Now that query is only executed after user is authenticated, error shouldn't exist anymore.

[YM-376](https://helsinkisolutionoffice.atlassian.net/browse/YM-376)

## How Has This Been Tested?

Changes has only tested manually by me.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
1) With `development` branch, start local environment with `yarn start`.
2) When process is running, enter the site again via address bar. You should see `[GraphQL error]: You don't have permissions` error in the browser console (refreshing won't trigger the error).
3) Change branches and repeat steps 1 & 2. You should not see the previously mentioned error.
