### PR TITLE
YM-380 | Modify own information e2e

### DIFF
--- a/browser-tests/editMembershipInformationView.ts
+++ b/browser-tests/editMembershipInformationView.ts
@@ -1,0 +1,100 @@
+import { testURL } from './utils/settings';
+import { loginStraight } from './utils/login';
+import { membershipInformationSelector } from './pages/membershipInformationSelector';
+import { registrationFormSelector } from './pages/registrationFormSelector';
+
+fixture('Edit profile information').page(testURL());
+
+const fillAddressAndPhone = async (
+  t: TestController,
+  address: string,
+  postalCode: string,
+  city: string,
+  phone: string
+) => {
+  await t
+    .selectText(registrationFormSelector.primaryAddress)
+    .typeText(registrationFormSelector.primaryAddress, address)
+    .selectText(registrationFormSelector.primaryPostalCode)
+    .typeText(registrationFormSelector.primaryPostalCode, postalCode)
+    .selectText(registrationFormSelector.primaryCity)
+    .typeText(registrationFormSelector.primaryCity, city)
+    .selectText(registrationFormSelector.phone)
+    .typeText(registrationFormSelector.phone, phone);
+};
+
+const expectedValues = async (
+  t: TestController,
+  mainAddress: string,
+  phone: string,
+  photoUsage: string,
+  school: string
+) => {
+  await t
+    .expect(membershipInformationSelector.mainAddress.innerText)
+    .eql(mainAddress)
+    .expect(membershipInformationSelector.phone.innerText)
+    .eql(phone)
+    .expect(membershipInformationSelector.photoUsage.innerText)
+    .eql(photoUsage)
+    .expect(membershipInformationSelector.school.innerText)
+    .eql(school);
+};
+
+test('Edit profile information', async t => {
+  await loginStraight(t);
+
+  await t
+    .click(membershipInformationSelector.linkToProfile)
+    .click(membershipInformationSelector.editProfileButton);
+
+  // Make changes to information
+  await fillAddressAndPhone(
+    t,
+    'Space street',
+    '00000',
+    'MoonCity',
+    '7654321050'
+  );
+  await t
+    .click(registrationFormSelector.photoUsageYes)
+    .typeText(registrationFormSelector.schoolName, 'Solution office')
+    .typeText(registrationFormSelector.schoolClass, 'Team-C')
+    .click(registrationFormSelector.submitButton);
+
+  // Make sure information was changed
+  await expectedValues(
+    t,
+    'Space street, 00000, MoonCity, Sweden',
+    '7654321050',
+    'Yes',
+    'Solution office, Team-C'
+  );
+
+  // Change everything back. This way we can actually make sure that information is changed every time
+
+  await t.click(membershipInformationSelector.editProfileButton);
+  await fillAddressAndPhone(
+    t,
+    'Test street 101',
+    '00200',
+    'Helsinki',
+    '0501234567'
+  );
+  await t
+    .click(registrationFormSelector.photoUsageNo)
+    .selectText(registrationFormSelector.schoolName)
+    .pressKey('delete')
+    .selectText(registrationFormSelector.schoolClass)
+    .pressKey('delete')
+    .click(registrationFormSelector.submitButton);
+
+  // Check that information was changed back
+  await expectedValues(
+    t,
+    'Test street 101, 00200, Helsinki, Sweden',
+    '0501234567',
+    'No',
+    '–'
+  );
+});

--- a/browser-tests/pages/membershipInformationSelector.ts
+++ b/browser-tests/pages/membershipInformationSelector.ts
@@ -4,13 +4,25 @@ export const membershipInformationSelector = {
   qrCode: Selector('canvas[id="react-qrcode-logo"]'),
   linkToProfile: Selector('a').withText('Show profile information'),
   name: Selector('span').withText('Existing TestProfile'),
-  mainAddress: Selector('span').withText(
-    'Test street 101, 00200, Helsinki, Sweden'
-  ),
-  secondAddress: Selector('span').withText(
-    'Test street 202, 00100, Helsinki, Finland'
-  ),
+  mainAddress: Selector('strong')
+    .withText('Address')
+    .sibling('span'),
+  secondAddress: Selector('strong')
+    .withText('Address 2')
+    .sibling('span'),
+  phone: Selector('strong')
+    .withText('Phone')
+    .sibling('span'),
+  school: Selector('strong')
+    .withText('School')
+    .sibling('span'),
+  photoUsage: Selector('strong')
+    .withText('Photo usage approved')
+    .sibling('span'),
   approvers: Selector('h2')
     .withText('Approver information')
     .sibling('div'),
+  editProfileButton: Selector('a[class^="hds-button"]').withText(
+    'Edit information'
+  ),
 };

--- a/src/domain/youthProfile/helpers/youthProfileGetters.ts
+++ b/src/domain/youthProfile/helpers/youthProfileGetters.ts
@@ -17,7 +17,7 @@ function handleAge(
   formValues: FormValues
 ): YouthProfileFields {
   const age = differenceInYears(new Date(), new Date(formValues.birthDate));
-  const isOldEnough = age > ageConstants.PHOTO_PERMISSION_MIN;
+  const isOldEnough = age >= ageConstants.PHOTO_PERMISSION_MIN;
   const photoUsageApproved = formValues.photoUsageApproved === 'true';
 
   return isOldEnough


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added `e2e` tests for testing profile information edit functionality. While writing these, tests actually pointed that `photoUsagePermission` field changes were not saved even user was at required age. I included that fix to this PR.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
More `e2e` tests.

[YM-380](https://helsinkisolutionoffice.atlassian.net/browse/YM-380)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
`yarn browser-test` -> all tests pass

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
1) Add values to `.env` file (if you don't have these you can contact me):
- `REACT_APP_TESTING_USERNAME`
- `REACT_APP_TESTING_PASSWORD`
- `REACT_APP_TESTING_USERNAME_WITH_PROFILE`
2) Login to [profile-admin](https://profiili-api.test.kuva.hel.ninja/admin) and make sure "Uno User" has no profile
3) Start local application `yarn start`
4) Run `yarn browser-test`
5) Delete the created profile to avoid crashing next time tests are run.
