### PR TITLE
YM-410 | E2e emails and approval

### DIFF
--- a/browser-tests/pages/membershipInformationSelector.ts
+++ b/browser-tests/pages/membershipInformationSelector.ts
@@ -2,6 +2,13 @@ import { Selector } from 'testcafe';
 
 export const membershipInformationSelector = {
   qrCode: Selector('canvas[id="react-qrcode-logo"]'),
+  approverEmailSent: Selector('h1').withText(
+    'The application has been sent to your guardian for approval!'
+  ),
+  resendApprovalEmai: Selector('button').withText(
+    'Resend the membership request'
+  ),
+  displayApplication: Selector('a[class^="hds-button"]'),
   linkToProfile: Selector('a').withText('Show profile information'),
   name: Selector('span').withText('Existing TestProfile'),
   mainAddress: Selector('strong')
@@ -25,4 +32,5 @@ export const membershipInformationSelector = {
   editProfileButton: Selector('a[class^="hds-button"]').withText(
     'Edit information'
   ),
+  goBack: Selector('a[class^="hds-button"]'),
 };

--- a/browser-tests/pages/registrationFormSelector.ts
+++ b/browser-tests/pages/registrationFormSelector.ts
@@ -47,6 +47,7 @@ export const registrationFormSelector = {
   additionalApproverPhone: Selector(
     'input[name="additionalContactPersons.0.phone"]'
   ),
+  textInputErrors: Selector('div[class^="TextInput-module_helperText"]'),
   terms: Selector('input[type="checkbox"]'),
   submitButton: Selector('button[type="submit"]'),
 };

--- a/browser-tests/utils/settings.ts
+++ b/browser-tests/utils/settings.ts
@@ -36,3 +36,18 @@ export const testURL = () => {
       return LOCAL_URL;
   }
 };
+
+export const mailosaurApiKey = (): string => {
+  if (!process.env.REACT_APP_MAILOSAUR_API) {
+    throw new Error('No REACT_APP_MAILOSAUR_API specified');
+  }
+
+  return process.env.REACT_APP_MAILOSAUR_API;
+};
+export const mailosaurServerId = (): string => {
+  if (!process.env.REACT_APP_MAILOSAUR_SERVER_ID) {
+    throw new Error('No REACT_APP_MAILOSAUR_SERVER_ID specified');
+  }
+
+  return process.env.REACT_APP_MAILOSAUR_SERVER_ID;
+};

--- a/browser-tests/utils/valueUtils.ts
+++ b/browser-tests/utils/valueUtils.ts
@@ -1,3 +1,7 @@
+import { Message } from 'mailosaur/lib/models';
+import { get, nth } from 'lodash';
+import { testURL } from './settings';
+
 export const hasLength = (element: Element) => {
   if (!element.textContent) {
     return false;
@@ -5,4 +9,14 @@ export const hasLength = (element: Element) => {
 
   const text = element.textContent.trim();
   return text.length > 0;
+};
+
+export const getApproverUrl = async (message: Message): Promise<string> => {
+  const url = get(message, 'html.links[0].href');
+
+  if (url) {
+    const urlParts = url?.split('approve');
+    return `${testURL()}/approve${nth(urlParts, 1)}`;
+  }
+  return `${testURL()}/approve/`;
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "i18next": "^17.3.0",
     "i18next-browser-languagedetector": "^4.0.1",
     "lodash": "^4.17.19",
+    "mailosaur": "^6.0.10",
     "oidc-client": "^1.10.1",
     "postcode-validator": "^3.1.0",
     "react": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7994,6 +7994,14 @@ https-proxy-agent@^4.0.0:
     agent-base "5"
     debug "4"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
@@ -9726,6 +9734,13 @@ lru-cache@^5.0.0, lru-cache@^5.1.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   dependencies:
     yallist "^3.0.2"
+
+mailosaur@^6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/mailosaur/-/mailosaur-6.0.10.tgz#787a0c68cea36a44998808079bf00c02576f37cc"
+  integrity sha512-qHzOeBM3h7ZMIFrI7nlLUIZELVogoRsexQRPe3rzprBEk6fLPmxTuSsBmHtFnk3MJV2WSaslQPaBD31DWUhGCg==
+  dependencies:
+    https-proxy-agent "^5.0.0"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added `e2e` - tests for testing:
- User under 18 sees "waiting view" after registration
- Approval email is sent
- Re-sending approval email
- Approval view
- User information is shown after profile is approved

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
More `e2e` - tests.

[YM-410](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
`yarn browser-test` -> all test pass.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
1) Add values to `.env` file (if you don't have these you can contact me):
- `REACT_APP_TESTING_USERNAME`
- `REACT_APP_TESTING_PASSWORD`
- `REACT_APP_TESTING_USERNAME_WITH_PROFILE`
- `REACT_APP_MAILOSAUR_API`
- `REACT_APP_MAILOSAUR_SERVER_ID`
2) Login to [profile-admin](https://profiili-api.test.kuva.hel.ninja/admin) and make sure "Uno User" has no profile
3) Start local application `yarn start`
4) Run `yarn browser-test`
5) Delete the created profile (Uno User) to avoid crashing next time tests are run. **DO NOT DELETE Existing TestProfile**

