### PR TITLE
YM-405 | Centralize Apollo and Sentry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [Unreleased]
+### Fixed
+- Logging uninteresting error messages to Sentry
+
 ## [1.1.1] - 2020-10-07
 ### Added
 - e2e - tests for viewing own information

--- a/src/domain/app/AppYouthProfileRoute.tsx
+++ b/src/domain/app/AppYouthProfileRoute.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { Route, Redirect, RouteProps } from 'react-router';
 import { useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
-import * as Sentry from '@sentry/browser';
 import { useTranslation } from 'react-i18next';
 import { isValid, parseISO } from 'date-fns';
 
@@ -10,7 +9,6 @@ import { HasYouthProfile } from '../../graphql/generatedTypes';
 import getCookie from '../../common/helpers/getCookie';
 import LoadingContent from '../../common/components/loading/LoadingContent';
 import NotificationComponent from '../../common/components/notification/NotificationComponent';
-import authConstants from '../auth/constants/authConstants';
 
 const HAS_YOUTH_PROFILE = loader(
   '../youthProfile/graphql/HasYouthProfile.graphql'
@@ -23,17 +21,8 @@ function AppYouthProfileRoute(props: Props) {
   const [showNotification, setShowNotification] = useState<boolean>(false);
 
   const { data, loading } = useQuery<HasYouthProfile>(HAS_YOUTH_PROFILE, {
-    onError: error => {
-      // It's too difficult to block the profile from being loaded before authentication is finished.
-      // Instead we allow the UI to optimistically request the profile before it has the authorisation to do so.
-      // Because we ignore the subsequent permissions error, the user experience is not affected.
-      // Other errors should be shown to the user and be passed to Sentry.
-      error.graphQLErrors.forEach(qlError => {
-        if (qlError.message !== authConstants.PERMISSION_DENIED) {
-          Sentry.captureException(qlError);
-          setShowNotification(true);
-        }
-      });
+    onError: () => {
+      setShowNotification(true);
     },
   });
 

--- a/src/domain/membership/information/MembershipInformationPage.tsx
+++ b/src/domain/membership/information/MembershipInformationPage.tsx
@@ -26,8 +26,7 @@ function MembershipInformationPage() {
   const { data, loading } = useQuery<MembershipInformationTypes>(
     MEMBERSHIP_INFORMATION,
     {
-      onError: (error: Error) => {
-        Sentry.captureException(error);
+      onError: () => {
         setShowNotification(true);
       },
     }

--- a/src/domain/membership/useIsMembershipPending.ts
+++ b/src/domain/membership/useIsMembershipPending.ts
@@ -1,6 +1,5 @@
 import { useQuery, QueryHookOptions } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
-import * as Sentry from '@sentry/browser';
 import { ApolloError } from 'apollo-boost';
 
 import {
@@ -17,8 +16,6 @@ type Props = QueryHookOptions<HasYouthProfile, Record<string, unknown>>;
 function useIsMembershipPending({ onError }: Props) {
   const { data, loading } = useQuery<HasYouthProfile>(HAS_YOUTH_PROFILE, {
     onError: (error: ApolloError) => {
-      Sentry.captureException(error);
-
       if (onError) {
         onError(error);
       }

--- a/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
@@ -39,8 +39,7 @@ function ApproveYouthProfilePage() {
     PROFILE_BY_TOKEN,
     {
       variables: { token: params.token },
-      onError: (error: Error) => {
-        Sentry.captureException(error);
+      onError: () => {
         setShowNotification(true);
       },
       fetchPolicy: 'network-only',

--- a/src/domain/youthProfile/create/CreateYouthProfilePage.tsx
+++ b/src/domain/youthProfile/create/CreateYouthProfilePage.tsx
@@ -3,7 +3,6 @@ import { useHistory, Redirect } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
-import * as Sentry from '@sentry/browser';
 import { User } from 'oidc-client';
 
 import { PrefillRegistartion } from '../../../graphql/generatedTypes';
@@ -24,8 +23,7 @@ function CreateYouthProfilePage() {
   const { data, loading: loadingPrefillData } = useQuery<PrefillRegistartion>(
     PREFILL_REGISTRATION,
     {
-      onError: (error: Error) => {
-        Sentry.captureException(error);
+      onError: () => {
         setShowNotification(true);
       },
     }

--- a/src/domain/youthProfile/sent/SentYouthProfile.tsx
+++ b/src/domain/youthProfile/sent/SentYouthProfile.tsx
@@ -23,8 +23,7 @@ function ViewYouthProfile(props: Props) {
   const [showNotification, setShowNotification] = useState(false);
   const [emailReSent, setEmailReSent] = useState(false);
   const { data } = useQuery<ApproverEmail>(APPROVER_EMAIL, {
-    onError: (error: Error) => {
-      Sentry.captureException(error);
+    onError: () => {
       setShowNotification(true);
     },
   });

--- a/src/graphql/__tests__/handleError.test.ts
+++ b/src/graphql/__tests__/handleError.test.ts
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import { GraphQLError } from 'graphql';
+import { Operation } from 'apollo-boost';
+import * as Sentry from '@sentry/browser';
+
+import * as config from '../config';
+import handleError from '../handleError';
+
+jest.mock('../config');
+
+const graphQLError = ({
+  message: 'Message',
+  extensions: {
+    code: 'TEST',
+  },
+  locations: [],
+  path: ['myTest'],
+} as unknown) as GraphQLError;
+
+const operation = ({
+  operationName: 'Test',
+  query: {
+    definitions: [
+      {
+        kind: 'OperationDefinition',
+        operation: 'query',
+      },
+    ],
+  },
+} as unknown) as Operation;
+
+describe('handleError', () => {
+  let ignoreRules: unknown;
+
+  beforeEach(() => {
+    ignoreRules = config.ignoreErrorRules;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    // @ts-ignore
+    // eslint-disable-next-line import/namespace
+    config.ignoreErrorRules = ignoreRules;
+  });
+
+  describe('GraphQL errors', () => {
+    it('should send graphQL errors', () => {
+      const mockScope = {
+        setLevel: jest.fn(),
+        setTag: jest.fn(),
+        setContext: jest.fn(),
+        setExtra: jest.fn(),
+      };
+      const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+      const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+      const withScopeSpy = jest.spyOn(Sentry, 'withScope');
+
+      // @ts-ignore
+      withScopeSpy.mockImplementation(cb => cb(mockScope));
+
+      // @ts-ignore
+      handleError({ graphQLErrors: [graphQLError], operation });
+
+      expect(withScopeSpy).toHaveBeenCalledTimes(1);
+      expect(mockScope.setLevel).toHaveBeenCalledWith('error');
+      expect(mockScope.setTag).toHaveBeenCalledWith('type', 'GraphQL Error');
+      expect(mockScope.setTag).toHaveBeenCalledWith('operation.kind', 'query');
+      expect(mockScope.setContext).toHaveBeenCalledWith(
+        'GraphQL Error',
+        expect.any(Object)
+      );
+      expect(mockScope.setContext).toHaveBeenCalledWith(
+        'Operation',
+        expect.any(Object)
+      );
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+      expect(captureMessageSpy).toHaveBeenCalledWith(graphQLError.message);
+    });
+
+    it('should allow errors to be ignored', () => {
+      const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+      const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+
+      // @ts-ignore
+      // eslint-disable-next-line import/namespace
+      config.ignoreErrorRules = [
+        [operation.operationName, graphQLError.extensions?.code],
+      ];
+
+      // @ts-ignore
+      handleError({ graphQLErrors: [graphQLError], operation });
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+      expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('should allow errors to be consumed', () => {
+      const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+      const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+      const response = {
+        errors: 'Some error',
+      };
+
+      // @ts-ignore
+      // eslint-disable-next-line import/namespace
+      config.ignoreErrorRules = [
+        [operation.operationName, graphQLError.extensions?.code, true],
+      ];
+
+      // @ts-ignore
+      handleError({ graphQLErrors: [graphQLError], operation, response });
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(0);
+      expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+      expect(response.errors).toBeUndefined();
+    });
+  });
+
+  describe('network errors', () => {
+    it('should send network errors', () => {
+      const error = Error('Test');
+      const mockScope = {
+        setTag: jest.fn(),
+      };
+      const captureExceptionSpy = jest.spyOn(Sentry, 'captureException');
+      const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+      const withScopeSpy = jest.spyOn(Sentry, 'withScope');
+
+      // @ts-ignore
+      withScopeSpy.mockImplementation(cb => cb(mockScope));
+
+      // @ts-ignore
+      handleError({ networkError: error, operation });
+
+      expect(withScopeSpy).toHaveBeenCalledTimes(1);
+      expect(mockScope.setTag).toHaveBeenCalledWith('type', 'Network Error');
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+      expect(captureMessageSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -5,6 +5,7 @@ import { profileApiTokenSelector } from '../domain/auth/redux';
 import getAuthenticatedUser from '../domain/auth/getAuthenticatedUser';
 import fetchApiToken from '../domain/auth/fetchApiToken';
 import pickProfileApiToken from '../domain/auth/pickProfileApiToken';
+import handleError from './handleError';
 
 const getToken = async () => {
   try {
@@ -34,4 +35,5 @@ export default new ApolloClient({
     }
   },
   uri: process.env.REACT_APP_PROFILE_GRAPHQL,
+  onError: handleError,
 });

--- a/src/graphql/config.ts
+++ b/src/graphql/config.ts
@@ -1,0 +1,60 @@
+import { DocumentNode, OperationDefinitionNode } from 'graphql';
+import { loader } from 'graphql.macro';
+
+import { ErrorCode } from './errorCodes';
+
+const HAS_YOUTH_PROFILE = loader(
+  '../domain/youthProfile/graphql/HasYouthProfile.graphql'
+);
+const PREFILL_REGISTRATION = loader(
+  '../domain/youthProfile/graphql/PrefillRegistration.graphql'
+);
+
+function getName(document?: DocumentNode): string {
+  if (!document) {
+    throw Error('No document found');
+  }
+
+  const operation = document.definitions.find(
+    (definition): definition is OperationDefinitionNode =>
+      definition.kind === 'OperationDefinition'
+  );
+
+  if (!operation) {
+    throw Error('No operation definition found from document');
+  }
+
+  if (!operation.name) {
+    throw Error('Operation definitions did not have name');
+  }
+
+  return operation.name.value;
+}
+
+// Operation name, error code, shouldConsume
+export type IgnoreRule = [string, ErrorCode, boolean];
+
+type IgnoreInput =
+  | [DocumentNode | undefined, ErrorCode]
+  | [DocumentNode | undefined, ErrorCode, boolean];
+
+function createIgnoreErrorsConfig(ignoreInput: IgnoreInput[]): IgnoreRule[] {
+  const ignoreErrorRules: IgnoreRule[] = [];
+
+  ignoreInput.forEach(([document, errorCode, shouldConsume = false]) => {
+    try {
+      const name = getName(document);
+
+      ignoreErrorRules.push([name, errorCode, shouldConsume]);
+    } catch (e) {
+      throw e;
+    }
+  });
+
+  return ignoreErrorRules;
+}
+
+export const ignoreErrorRules: IgnoreRule[] = createIgnoreErrorsConfig([
+  [HAS_YOUTH_PROFILE, 'PERMISSION_DENIED_ERROR', true],
+  [PREFILL_REGISTRATION, 'PERMISSION_DENIED_ERROR', true],
+]);

--- a/src/graphql/errorCodes.ts
+++ b/src/graphql/errorCodes.ts
@@ -1,0 +1,5 @@
+export const ErrorCodes = Object.freeze({
+  PERMISSION_DENIED_ERROR: 'PERMISSION_DENIED_ERROR',
+} as const);
+
+export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];

--- a/src/graphql/handleError.ts
+++ b/src/graphql/handleError.ts
@@ -1,0 +1,108 @@
+import { ErrorLink } from 'apollo-link-error';
+import * as Sentry from '@sentry/browser';
+import { GraphQLError, OperationDefinitionNode } from 'graphql';
+import { Operation } from 'apollo-boost';
+
+import { ignoreErrorRules } from './config';
+
+const stringify = (value: unknown) => JSON.stringify(value, null, 2);
+
+function getShouldIgnore(
+  operation: Operation,
+  graphQLError: GraphQLError
+): [boolean, boolean | null] {
+  const ignoreRule = ignoreErrorRules.find(([operationName, errorCode]) => {
+    const isOperation = operationName === operation.operationName;
+    const isError = graphQLError?.extensions?.code === errorCode;
+
+    return isOperation && isError;
+  });
+
+  if (!ignoreRule) {
+    return [false, null];
+  }
+
+  return [true, ignoreRule[2]];
+}
+
+function handleError({
+  networkError,
+  graphQLErrors,
+  operation,
+  response,
+}: Parameters<ErrorLink.ErrorHandler>[0]): ReturnType<ErrorLink.ErrorHandler> {
+  // Remember to not log variables or queries unless you are sure that
+  // they don't contain any personal information!
+  if (graphQLErrors) {
+    graphQLErrors.forEach(graphQLError => {
+      const [shouldIgnore, shouldConsume] = getShouldIgnore(
+        operation,
+        graphQLError
+      );
+      // For some errors we do not want to log entries into Sentry. Often
+      // these errors are permissions related errors we know to expect
+      // and can't avoid.
+      if (shouldIgnore) {
+        // Sometimes we don't want to pass down the error in which case
+        // we "consume" it. This means that for instance hooks are not
+        // called with this error. Note that stopping one error from
+        // being passed will stop all the rest as well.
+        // https://www.apollographql.com/docs/react/data/error-handling/#ignoring-errors
+        if (shouldConsume && response) {
+          delete response['errors'];
+        }
+        return;
+      }
+
+      const {
+        originalError,
+        extensions,
+        locations,
+        message,
+        path,
+      } = graphQLError;
+
+      Sentry.withScope(scope => {
+        const operationName = operation.operationName;
+        const operationKind = operation.query.definitions.find(
+          (definition): definition is OperationDefinitionNode =>
+            definition.kind === 'OperationDefinition'
+        )?.operation;
+
+        scope.setLevel(Sentry.Severity.Error);
+
+        scope.setTag('type', 'GraphQL Error');
+        scope.setTag('operation.name', operationName);
+        if (operationKind) {
+          scope.setTag('operation.kind', operationKind);
+        }
+
+        scope.setContext('GraphQL Error', {
+          extensions: stringify(extensions),
+          locations: stringify(locations),
+          path: stringify(path),
+        });
+        scope.setContext('Operation', {
+          name: operationName,
+          kind: operationKind,
+        });
+
+        if (originalError) {
+          scope.setExtra('message', message);
+          Sentry.captureException(originalError);
+        } else {
+          Sentry.captureMessage(message);
+        }
+      });
+    });
+  }
+
+  if (networkError) {
+    Sentry.withScope(scope => {
+      scope.setTag('type', 'Network Error');
+      Sentry.captureException(networkError);
+    });
+  }
+}
+
+export default handleError;


### PR DESCRIPTION
## Description

Previously the Apollo and Sentry integration was done multiple times at
multiple different places in the code. This commit centralizes this
logic by logging errors into Sentry by using the 'onError' field in
Apollo boost's client.

This centralized error handling adds more context to the data we pass
on to Sentry. This makes debugging easier by allowing us to see the
name of the query that caused an error, for instance. This kind of
context couldn't have been added without centralization.

This change also implements a centralized error ignoring mechanism.
We know that we do not want to pass some errors to Sentry, because the
errors we receive are expected. Such error often include for instance
permission related errors. Now such errors can be ignored globally,
making it less likely that we forget to ignore them in some view.

Errors can be ignore or consumed. Ignored errors won't be sent to
Sentry, but they will be sent to consumers like 'useQuery' hooks. When
an error is consumed, it won't be passed on to consumers, in which case
'useQuery' hook's 'onError' callback would not be called.

Note that when consuming en error, the entire error object is consumed.
This means that if one error in an error object containing two errors
is consumed, both errors are consumed.

Note that global error consuming should be used scarcely. It should be
reserved for those errors of whose exclusion the view layer clearly
benefits from.

The following changes were made into the data that is sent into Sentry
- GraphQL errors are now sen as errors instead of info
- The following tags were added (can be used to search)
    - GraphQL Errors
        - *type:* Always with the value `GraphQL Error`
        - *operation.name:* The name of the query or mutation that caused the error
        - *operation.kind:* The kind of operation that caused the error (`query`/`mutation`/ `subscription`)
   - Network Error
        - *type:* Always with the value `Network Error`
- The following contexts were added into GraphQL errors
    - GraphQL Error
         - *extensions:* Stringified JSON of extensions. May contain, for instance, the error code.
         - *locations:* Stringified JSON of the location of the error.
         - *path:* Stringified JSON of the path of the error.
    - Operation
         - *name:* Name of operation.
         - *kind:* The kind of the operation.

## Context
I set out to fix YM-405. Because the errors in Sentry were a bit vague, I looked into how to add more contextual data. I found Apollo's documentation for error handling, which guides towards using the `onError` prop: https://www.apollographql.com/docs/react/data/error-handling/. I felt that this extra context was useful enough to have to warrant some refactoring.

This change also fixes another pet-peeve I've had with this application--Sentry logging is done on bit all over the place. With these changes, Sentry integrates into Apollo in one place. I removed all the Sentry calls I knew were redundant. However, some duplicate logging may have remained in mutation calls. Some of these  had the potential to catch errors that were not Apollo related so I left them in. 

[YM-405](https://helsinkisolutionoffice.atlassian.net/browse/YM-405)

## How Has This Been Tested?
I've added unit tests for the `handleError` function. These rather ruthlessly mock `Sentry` and `configs`. The fix I saw for this was to parameterise the code I was mocking, but I felt that it was a good tradeoff to avoid doing that for now.

I also logged events from my local installation into Sentry with a special environment name and release name so that I could easily clean them up. I reproduced the error YM-405 was about and debugged it by adding more context. I then checked that those errors were no longer logged into Sentry after I had ignored them.

## Manual Testing Instructions for Reviewers

As a non logged in user

1. Go to `/create`
2. Go to Sentry and verify that no error was generated there