### PR TITLE
YM-390 | Edit mutations work with federation

### DIFF
--- a/src/common/test/testUtils.tsx
+++ b/src/common/test/testUtils.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { MockedProvider, MockedResponse } from '@apollo/react-testing';
+import { MemoryRouter } from 'react-router';
 
 import store from '../../redux/store';
 
@@ -12,25 +13,17 @@ export const mountWithProvider = (children: ReactElement) =>
 export const shallowWithProvider = (children: ReactElement) =>
   shallow(<Provider store={store}>{children}</Provider>);
 
-export const mountWithApolloProvider = (
-  children: ReactElement,
-  mocks?: MockedResponse[]
-) =>
-  mount(
-    <MockedProvider mocks={mocks} addTypename={true}>
-      {children}
-    </MockedProvider>
-  );
-
-export const mountWithApolloAndReduxProviders = (
+export const mountWithProviders = (
   children: ReactElement,
   mocks?: MockedResponse[]
 ) =>
   mount(
     <Provider store={store}>
-      <MockedProvider mocks={mocks} addTypename={true}>
-        {children}
-      </MockedProvider>
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={true}>
+          {children}
+        </MockedProvider>
+      </MemoryRouter>
     </Provider>
   );
 /* eslint-disable  @typescript-eslint/no-explicit-any */

--- a/src/common/test/testUtils.tsx
+++ b/src/common/test/testUtils.tsx
@@ -21,6 +21,18 @@ export const mountWithApolloProvider = (
       {children}
     </MockedProvider>
   );
+
+export const mountWithApolloAndReduxProviders = (
+  children: ReactElement,
+  mocks?: MockedResponse[]
+) =>
+  mount(
+    <Provider store={store}>
+      <MockedProvider mocks={mocks} addTypename={true}>
+        {children}
+      </MockedProvider>
+    </Provider>
+  );
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export const updateWrapper = async (wrapper: any) => {
   await act(async () => {

--- a/src/domain/membership/details/__tests__/MembershipDetailsPage.test.tsx
+++ b/src/domain/membership/details/__tests__/MembershipDetailsPage.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router';
 import { loader } from 'graphql.macro';
 
 import { membershipDetailsData } from '../../../../common/test/membershipDetailsData';
 import MembershipDetailsPage from '../MembershipDetailsPage';
 import {
-  mountWithApolloProvider,
+  mountWithProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 
@@ -44,12 +43,7 @@ const expectedValues = [
 ];
 
 const getWrapper = () => {
-  return mountWithApolloProvider(
-    <MemoryRouter>
-      <MembershipDetailsPage />
-    </MemoryRouter>,
-    mocks
-  );
+  return mountWithProviders(<MembershipDetailsPage />, mocks);
 };
 
 type ComponentValues = {

--- a/src/domain/membership/information/MembershipInformationPage.tsx
+++ b/src/domain/membership/information/MembershipInformationPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import * as Sentry from '@sentry/browser';
 
 import {
@@ -9,6 +10,7 @@ import {
   RenewMyYouthProfileVariables,
   MembershipInformation as MembershipInformationTypes,
 } from '../../../graphql/generatedTypes';
+import { profileApiTokenSelector } from '../../auth/redux';
 import NotificationComponent from '../../../common/components/notification/NotificationComponent';
 import PageContentWithHostingBox from '../../../common/components/layout/PageContentWithHostingBox';
 import MembershipInformation from './MembershipInformation';
@@ -22,6 +24,7 @@ function MembershipInformationPage() {
   const [showNotification, setShowNotification] = useState(false);
   const [successNotification, setSuccessNotification] = useState(false);
   const { t } = useTranslation();
+  const profileApiToken = useSelector(profileApiTokenSelector);
 
   const { data, loading } = useQuery<MembershipInformationTypes>(
     MEMBERSHIP_INFORMATION,
@@ -38,7 +41,9 @@ function MembershipInformationPage() {
 
   const handleRenewMembership = () => {
     const variables: RenewMyYouthProfileVariables = {
-      input: {},
+      input: {
+        profileApiToken,
+      },
     };
 
     renewMembership({ variables })

--- a/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
+++ b/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
@@ -3,7 +3,7 @@ import { loader } from 'graphql.macro';
 import { MemoryRouter } from 'react-router-dom';
 
 import {
-  mountWithApolloAndReduxProviders,
+  mountWithProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 import MembershipInformationPage from '../MembershipInformationPage';
@@ -38,7 +38,7 @@ const mocks = [
 ];
 
 it('mocked data is found', async () => {
-  const wrapper = mountWithApolloAndReduxProviders(
+  const wrapper = mountWithProviders(
     <MemoryRouter>
       <MembershipInformationPage />
     </MemoryRouter>,
@@ -59,7 +59,7 @@ it('mocked data is found', async () => {
 it('renew button is shown', async () => {
   mocks[0].result.data.myYouthProfile.renewable = true;
 
-  const wrapper = mountWithApolloAndReduxProviders(
+  const wrapper = mountWithProviders(
     <MemoryRouter>
       <MembershipInformationPage />
     </MemoryRouter>,

--- a/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
+++ b/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { MockedProvider } from '@apollo/react-testing';
 import { loader } from 'graphql.macro';
 import { MemoryRouter } from 'react-router-dom';
 
+import {
+  mountWithApolloAndReduxProviders,
+  updateWrapper,
+} from '../../../../common/test/testUtils';
 import MembershipInformationPage from '../MembershipInformationPage';
-import { updateWrapper } from '../../../../common/test/testUtils';
 
 const MEMBERSHIP_INFORMATION = loader(
   '../../graphql/MembershipInformation.graphql'
@@ -24,10 +25,12 @@ const mocks = [
             id: '123',
             firstName: 'Teemu',
             lastName: 'Testaaja',
+            __typename: 'ProfileNode',
           },
           expiration: '2020-02-02',
           renewable: false,
           membershipNumber: '01234',
+          __typename: 'YouthProfileNode',
         },
       },
     },
@@ -35,12 +38,11 @@ const mocks = [
 ];
 
 it('mocked data is found', async () => {
-  const wrapper = mount(
+  const wrapper = mountWithApolloAndReduxProviders(
     <MemoryRouter>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <MembershipInformationPage />
-      </MockedProvider>
-    </MemoryRouter>
+      <MembershipInformationPage />
+    </MemoryRouter>,
+    mocks
   );
 
   await updateWrapper(wrapper);
@@ -57,12 +59,11 @@ it('mocked data is found', async () => {
 it('renew button is shown', async () => {
   mocks[0].result.data.myYouthProfile.renewable = true;
 
-  const wrapper = mount(
+  const wrapper = mountWithApolloAndReduxProviders(
     <MemoryRouter>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <MembershipInformationPage />
-      </MockedProvider>
-    </MemoryRouter>
+      <MembershipInformationPage />
+    </MemoryRouter>,
+    mocks
   );
 
   await updateWrapper(wrapper);

--- a/src/domain/youthProfile/create/__tests__/CreateYouthProfilePage.test.tsx
+++ b/src/domain/youthProfile/create/__tests__/CreateYouthProfilePage.test.tsx
@@ -3,11 +3,9 @@ import { MockedResponse } from '@apollo/react-testing';
 import { User } from 'oidc-client';
 import { loader } from 'graphql.macro';
 import { act } from 'react-dom/test-utils';
-import { MemoryRouter } from 'react-router';
-import { Provider } from 'react-redux';
 
 import {
-  mountWithApolloProvider,
+  mountWithProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 import i18n from '../../../../common/test/testi18nInit';
@@ -17,7 +15,6 @@ import {
   Language,
   PrefillRegistartion,
 } from '../../../../graphql/generatedTypes';
-import store from '../../../../redux/store';
 
 /* eslint-disable @typescript-eslint/camelcase */
 const mockTunnistamoUser: User = {
@@ -102,14 +99,7 @@ const getMocks = (myProfile: MyProfile) => {
 };
 
 const getWrapper = (mocks?: MockedResponse[]) => {
-  return mountWithApolloProvider(
-    <Provider store={store}>
-      <MemoryRouter>
-        <CreateYouthProfilePage />
-      </MemoryRouter>
-    </Provider>,
-    mocks
-  );
+  return mountWithProviders(<CreateYouthProfilePage />, mocks);
 };
 
 Object.defineProperty(window.document, 'cookie', {

--- a/src/domain/youthProfile/edit/EditYouthProfile.tsx
+++ b/src/domain/youthProfile/edit/EditYouthProfile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 import { loader } from 'graphql.macro';
+import { useHistory } from 'react-router';
 
 import {
   Language,
@@ -38,8 +39,11 @@ function EditYouthProfile(props: Props) {
     }
   );
 
+  const history = useHistory();
+
   const [updateProfiles, { loading }] = useUpdateProfiles({
     onError: () => setShowNotification(true),
+    onCompleted: () => history.push('/membership-details'),
   });
 
   const youthProfile = data?.myYouthProfile;

--- a/src/domain/youthProfile/edit/__tests__/EditYouthProfile.test.tsx
+++ b/src/domain/youthProfile/edit/__tests__/EditYouthProfile.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router';
 import { loader } from 'graphql.macro';
 
 import EditYouthProfile from '../EditYouthProfile';
 import { membershipDetailsData } from '../../../../common/test/membershipDetailsData';
 import {
-  mountWithApolloAndReduxProviders,
+  mountWithProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 
@@ -27,12 +26,7 @@ const mocks = [
 ];
 
 const getWrapper = () => {
-  return mountWithApolloAndReduxProviders(
-    <MemoryRouter>
-      <EditYouthProfile />
-    </MemoryRouter>,
-    mocks
-  );
+  return mountWithProviders(<EditYouthProfile />, mocks);
 };
 
 test('form has values', async () => {

--- a/src/domain/youthProfile/edit/__tests__/EditYouthProfile.test.tsx
+++ b/src/domain/youthProfile/edit/__tests__/EditYouthProfile.test.tsx
@@ -5,7 +5,7 @@ import { loader } from 'graphql.macro';
 import EditYouthProfile from '../EditYouthProfile';
 import { membershipDetailsData } from '../../../../common/test/membershipDetailsData';
 import {
-  mountWithApolloProvider,
+  mountWithApolloAndReduxProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 
@@ -27,7 +27,7 @@ const mocks = [
 ];
 
 const getWrapper = () => {
-  return mountWithApolloProvider(
+  return mountWithApolloAndReduxProviders(
     <MemoryRouter>
       <EditYouthProfile />
     </MemoryRouter>,

--- a/src/domain/youthProfile/helpers/__tests__/updateProfileMutationVariables.test.ts
+++ b/src/domain/youthProfile/helpers/__tests__/updateProfileMutationVariables.test.ts
@@ -7,6 +7,7 @@ import {
   YouthLanguage,
 } from '../../../../graphql/generatedTypes';
 import { getEditMutationVariables } from '../updateProfileMutationVariables';
+import { getEditYouthProfile } from '../youthProfileGetters';
 
 const formValues: FormValues = {
   firstName: 'Tina',
@@ -100,9 +101,10 @@ const profileData: MembershipDetails = {
 };
 
 test('test object is correct and all fields are present', () => {
-  const variables = getEditMutationVariables(formValues, profileData);
+  const profileVariables = getEditMutationVariables(formValues, profileData);
+  const youthProfileVariables = getEditYouthProfile(formValues, profileData);
 
-  const expectedResult = {
+  const expectedResultProfile = {
     input: {
       profile: {
         firstName: 'Tina',
@@ -118,23 +120,25 @@ test('test object is correct and all fields are present', () => {
             phoneType: PhoneType.OTHER,
           },
         ],
-        youthProfile: {
-          photoUsageApproved: false,
-          birthDate: '2000-01-01',
-          languageAtHome: YouthLanguage.FINNISH,
-          approverPhone: '0501234567',
-          approverEmail: 'gee@guardian.com',
-          approverLastName: 'Guardian',
-          approverFirstName: 'Gee',
-          schoolClass: '1S',
-          schoolName: 'Smooth School',
-          addAdditionalContactPersons: [],
-          updateAdditionalContactPersons: [],
-          removeAdditionalContactPersons: [],
-        },
       },
     },
   };
 
-  expect(variables).toEqual(expectedResult);
+  const expectedResultYouthProfile = {
+    photoUsageApproved: false,
+    birthDate: '2000-01-01',
+    languageAtHome: YouthLanguage.FINNISH,
+    approverPhone: '0501234567',
+    approverEmail: 'gee@guardian.com',
+    approverLastName: 'Guardian',
+    approverFirstName: 'Gee',
+    schoolClass: '1S',
+    schoolName: 'Smooth School',
+    addAdditionalContactPersons: [],
+    updateAdditionalContactPersons: [],
+    removeAdditionalContactPersons: [],
+  };
+
+  expect(profileVariables).toEqual(expectedResultProfile);
+  expect(youthProfileVariables).toEqual(expectedResultYouthProfile);
 });

--- a/src/domain/youthProfile/helpers/updateProfileMutationVariables.ts
+++ b/src/domain/youthProfile/helpers/updateProfileMutationVariables.ts
@@ -1,7 +1,6 @@
 import { MembershipDetails, PhoneType } from '../../../graphql/generatedTypes';
 import { Values as FormValues } from '../form/YouthProfileForm';
 import { getAddress } from './createProfileMutationVariables';
-import { getEditYouthProfile } from './youthProfileGetters';
 
 const getEditMutationVariables = (
   formValues: FormValues,
@@ -23,7 +22,6 @@ const getEditMutationVariables = (
               }
             : null,
         ],
-        youthProfile: getEditYouthProfile(formValues, profile),
       },
     },
   };

--- a/src/domain/youthProfile/hooks/useUpdateProfiles.ts
+++ b/src/domain/youthProfile/hooks/useUpdateProfiles.ts
@@ -1,0 +1,80 @@
+import { useMutation } from '@apollo/react-hooks';
+import { useHistory } from 'react-router';
+import { useSelector } from 'react-redux';
+import * as Sentry from '@sentry/browser';
+import { loader } from 'graphql.macro';
+
+import { Values as FormValues } from '../form/YouthProfileForm';
+import {
+  MembershipDetails,
+  UpdateMyProfile as UpdateMyProfileData,
+  UpdateMyProfileVariables,
+  UpdateMyYouthProfile as UpdateMyYouthProfileData,
+  UpdateMyYouthProfileVariables,
+} from '../../../graphql/generatedTypes';
+import { getEditMutationVariables } from '../helpers/updateProfileMutationVariables';
+import { getEditYouthProfile } from '../helpers/youthProfileGetters';
+import { profileApiTokenSelector } from '../../auth/redux';
+
+const UPDATE_MY_PROFILE = loader('../graphql/UpdateMyProfile.graphql');
+const UPDATE_MY_YOUTH_PROFILE = loader(
+  '../graphql/UpdateMyYouthProfile.graphql'
+);
+
+type Options = {
+  onError: (e: Error) => void;
+};
+
+type UpdateProfileVariables = {
+  loading: boolean;
+};
+
+const useUpdateProfiles = ({ onError }: Options) => {
+  const history = useHistory();
+  const profileApiToken = useSelector(profileApiTokenSelector);
+
+  const [updateMyProfile, { loading: updatingMyProfile }] = useMutation<
+    UpdateMyProfileData,
+    UpdateMyProfileVariables
+  >(UPDATE_MY_PROFILE);
+  const [
+    updateMyYouthProfile,
+    { loading: updatingMyYouthProfile },
+  ] = useMutation<UpdateMyYouthProfileData, UpdateMyYouthProfileVariables>(
+    UPDATE_MY_YOUTH_PROFILE
+  );
+
+  const loading = updatingMyProfile || updatingMyYouthProfile;
+
+  const updateProfiles = async (
+    formValues: FormValues,
+    membershipData?: MembershipDetails
+  ) => {
+    const myProfileVariables: UpdateMyProfileVariables = getEditMutationVariables(
+      formValues,
+      membershipData
+    );
+    const myYouthProfileVariables: UpdateMyYouthProfileVariables = {
+      input: {
+        youthProfile: getEditYouthProfile(formValues, membershipData),
+        profileApiToken,
+      },
+    };
+
+    try {
+      await updateMyProfile({ variables: myProfileVariables });
+      await updateMyYouthProfile({ variables: myYouthProfileVariables });
+      history.push('/membership-details');
+    } catch (e) {
+      Sentry.captureException(e);
+      onError(e);
+    }
+  };
+
+  return [updateProfiles, { loading }] as [
+    (formValues: FormValues, membershipData?: MembershipDetails) => void,
+    UpdateProfileVariables
+  ];
+};
+
+export default useUpdateProfiles;

--- a/src/domain/youthProfile/hooks/useUpdateProfiles.ts
+++ b/src/domain/youthProfile/hooks/useUpdateProfiles.ts
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/react-hooks';
-import { useHistory } from 'react-router';
 import { useSelector } from 'react-redux';
 import * as Sentry from '@sentry/browser';
 import { loader } from 'graphql.macro';
@@ -23,14 +22,14 @@ const UPDATE_MY_YOUTH_PROFILE = loader(
 
 type Options = {
   onError: (e: Error) => void;
+  onCompleted: () => void;
 };
 
 type UpdateProfileVariables = {
   loading: boolean;
 };
 
-const useUpdateProfiles = ({ onError }: Options) => {
-  const history = useHistory();
+const useUpdateProfiles = ({ onError, onCompleted }: Options) => {
   const profileApiToken = useSelector(profileApiTokenSelector);
 
   const [updateMyProfile, { loading: updatingMyProfile }] = useMutation<
@@ -64,7 +63,7 @@ const useUpdateProfiles = ({ onError }: Options) => {
     try {
       await updateMyProfile({ variables: myProfileVariables });
       await updateMyYouthProfile({ variables: myYouthProfileVariables });
-      history.push('/membership-details');
+      onCompleted();
     } catch (e) {
       Sentry.captureException(e);
       onError(e);

--- a/src/domain/youthProfile/sent/SentYouthProfile.tsx
+++ b/src/domain/youthProfile/sent/SentYouthProfile.tsx
@@ -4,12 +4,14 @@ import { loader } from 'graphql.macro';
 import { useTranslation } from 'react-i18next';
 import * as Sentry from '@sentry/browser';
 import { Button } from 'hds-react';
+import { useSelector } from 'react-redux';
 
 import {
   ApproverEmail,
   UpdateMyYouthProfile as UpdateMyYouthProfileData,
   UpdateMyYouthProfileVariables,
 } from '../../../graphql/generatedTypes';
+import { profileApiTokenSelector } from '../../auth/redux';
 import LinkButton from '../../../common/components/linkButton/LinkButton';
 import NotificationComponent from '../../../common/components/notification/NotificationComponent';
 import styles from './sentYouthProfile.module.css';
@@ -28,6 +30,7 @@ function ViewYouthProfile(props: Props) {
     },
   });
   const { t } = useTranslation();
+  const profileApiToken = useSelector(profileApiTokenSelector);
 
   const [resendConfirmationEmail] = useMutation<
     UpdateMyYouthProfileData,
@@ -40,6 +43,7 @@ function ViewYouthProfile(props: Props) {
         youthProfile: {
           resendRequestNotification: true,
         },
+        profileApiToken,
       },
     };
     resendConfirmationEmail({ variables })

--- a/src/domain/youthProfile/sent/__tests_/SentYouthProfile.test.tsx
+++ b/src/domain/youthProfile/sent/__tests_/SentYouthProfile.test.tsx
@@ -5,7 +5,7 @@ import toJson from 'enzyme-to-json';
 
 import ViewYouthProfile from '../SentYouthProfile';
 import {
-  mountWithApolloProvider,
+  mountWithApolloAndReduxProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 
@@ -30,7 +30,7 @@ const mocks = [
 ];
 
 const getWrapper = () => {
-  return mountWithApolloProvider(
+  return mountWithApolloAndReduxProviders(
     <MemoryRouter>
       <ViewYouthProfile />
     </MemoryRouter>,

--- a/src/domain/youthProfile/sent/__tests_/SentYouthProfile.test.tsx
+++ b/src/domain/youthProfile/sent/__tests_/SentYouthProfile.test.tsx
@@ -5,7 +5,7 @@ import toJson from 'enzyme-to-json';
 
 import ViewYouthProfile from '../SentYouthProfile';
 import {
-  mountWithApolloAndReduxProviders,
+  mountWithProviders,
   updateWrapper,
 } from '../../../../common/test/testUtils';
 
@@ -30,7 +30,7 @@ const mocks = [
 ];
 
 const getWrapper = () => {
-  return mountWithApolloAndReduxProviders(
+  return mountWithProviders(
     <MemoryRouter>
       <ViewYouthProfile />
     </MemoryRouter>,

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -707,7 +707,7 @@ export interface AddServiceConnectionMutationInput {
 
 export interface ApproveYouthProfileMutationInput {
   readonly approvalToken: string;
-  readonly approvalData: YouthProfileFields;
+  readonly approvalData: YouthProfileInput;
   readonly clientMutationId?: string | null;
 }
 
@@ -773,19 +773,20 @@ export interface ProfileInput {
   readonly language?: Language | null;
   readonly contactMethod?: ContactMethod | null;
   readonly addEmails?: ReadonlyArray<(CreateEmailInput | null)> | null;
-  readonly updateEmails?: ReadonlyArray<(UpdateEmailInput | null)> | null;
-  readonly removeEmails?: ReadonlyArray<(string | null)> | null;
   readonly addPhones?: ReadonlyArray<(CreatePhoneInput | null)> | null;
-  readonly updatePhones?: ReadonlyArray<(UpdatePhoneInput | null)> | null;
-  readonly removePhones?: ReadonlyArray<(string | null)> | null;
   readonly addAddresses?: ReadonlyArray<(CreateAddressInput | null)> | null;
-  readonly updateAddresses?: ReadonlyArray<(UpdateAddressInput | null)> | null;
-  readonly removeAddresses?: ReadonlyArray<(string | null)> | null;
   readonly subscriptions?: ReadonlyArray<(SubscriptionInputType | null)> | null;
   readonly sensitivedata?: SensitiveDataFields | null;
+  readonly updateEmails?: ReadonlyArray<(UpdateEmailInput | null)> | null;
+  readonly removeEmails?: ReadonlyArray<(string | null)> | null;
+  readonly updatePhones?: ReadonlyArray<(UpdatePhoneInput | null)> | null;
+  readonly removePhones?: ReadonlyArray<(string | null)> | null;
+  readonly updateAddresses?: ReadonlyArray<(UpdateAddressInput | null)> | null;
+  readonly removeAddresses?: ReadonlyArray<(string | null)> | null;
 }
 
 export interface RenewMyYouthProfileMutationInput {
+  readonly profileApiToken: string;
   readonly clientMutationId?: string | null;
 }
 
@@ -837,19 +838,7 @@ export interface UpdateMyProfileMutationInput {
   readonly clientMutationId?: string | null;
 }
 
-export interface UpdateMyYouthProfileMutationInput {
-  readonly youthProfile: UpdateYouthProfileInput;
-  readonly clientMutationId?: string | null;
-}
-
-export interface UpdatePhoneInput {
-  readonly primary?: boolean | null;
-  readonly id: string;
-  readonly phone?: string | null;
-  readonly phoneType?: PhoneType | null;
-}
-
-export interface UpdateYouthProfileInput {
+export interface UpdateMyYouthProfileInput {
   readonly schoolName?: string | null;
   readonly schoolClass?: string | null;
   readonly languageAtHome?: YouthLanguage | null;
@@ -865,7 +854,20 @@ export interface UpdateYouthProfileInput {
   readonly resendRequestNotification?: boolean | null;
 }
 
-export interface YouthProfileFields {
+export interface UpdateMyYouthProfileMutationInput {
+  readonly youthProfile: UpdateMyYouthProfileInput;
+  readonly profileApiToken: string;
+  readonly clientMutationId?: string | null;
+}
+
+export interface UpdatePhoneInput {
+  readonly primary?: boolean | null;
+  readonly id: string;
+  readonly phone?: string | null;
+  readonly phoneType?: PhoneType | null;
+}
+
+export interface YouthProfileInput {
   readonly schoolName?: string | null;
   readonly schoolClass?: string | null;
   readonly languageAtHome?: YouthLanguage | null;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR changes resend email, renew membership and edit profile information mutations to work with federation. 

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
`-`

[YM-390](https://helsinkisolutionoffice.atlassian.net/browse/YM-390)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
Manually + `e2e`-tests (note that this branch is not up to date with development, where profile creation tests are skipped)

## Manual Testing Instructions for Reviewers
1) Create a youth profile (adult, emails are not yet received)
2) Editing youth profile data works
3) From jässäris django admin set expiration year to 2020
4) Expect renew button to show and pressing it renews membership succesfully
