### PR TITLE
YM-421 | Add temporary feedback link to membership info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
+### Added
+- Temporary feedback link button in membership information page
+
 ### Changed
 - Use GitHub actions instead of Travis
 

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -9,10 +9,6 @@ import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import getFullName from '../helpers/getFullName';
 import styles from './membershipInformation.module.css';
 
-const feedbackFormLink =
-  // eslint-disable-next-line max-len
-  'https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti';
-
 interface Props {
   onRenewMembership: () => void;
   membershipInformationTypes: MembershipInformationTypes;
@@ -67,7 +63,7 @@ function MembershipInformation({
           />
           <LinkButton
             className={styles.button}
-            path={feedbackFormLink}
+            path={t('feedback.giveFeedback.link')}
             component="a"
             buttonText={t('feedback.giveFeedback.label')}
             variant="secondary"

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -5,9 +5,13 @@ import { Button } from 'hds-react';
 
 import { MembershipInformation as MembershipInformationTypes } from '../../../graphql/generatedTypes';
 import LinkButton from '../../../common/components/linkButton/LinkButton';
-import getFullName from '../helpers/getFullName';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
+import getFullName from '../helpers/getFullName';
 import styles from './membershipInformation.module.css';
+
+const feedbackFormLink =
+  // eslint-disable-next-line max-len
+  'https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti';
 
 interface Props {
   onRenewMembership: () => void;
@@ -40,6 +44,7 @@ function MembershipInformation({
           </p>
           <QRCode
             size={175}
+            // eslint-disable-next-line max-len
             value={`${process.env.REACT_APP_ADMIN_URL}youthProfiles/${membershipInformationTypes.youthProfile?.profile.id}/show`}
           />
            
@@ -58,6 +63,13 @@ function MembershipInformation({
             path="/membership-details"
             component="Link"
             buttonText={t('membershipInformation.showProfileInformation')}
+            variant="secondary"
+          />
+          <LinkButton
+            className={styles.button}
+            path={feedbackFormLink}
+            component="a"
+            buttonText={t('feedback.giveFeedback.label')}
             variant="secondary"
           />
         </React.Fragment>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,7 +20,7 @@
     "basicInfo": "Basic info",
     "birthDate": "Birthdate",
     "explanationError": "You have either already approved the application submitted by your youth or an error has occurred in our service.",
-    "explanationCheckStatus": "The youth can check his application status by logging in to Jässäri. Ask him to resend the confirmation message if his membership has not yet been approved.",
+    "explanationCheckStatus": "The youth can check his application status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
     "formExplanationText_1": "has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
     "formExplanationText_2": "may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
     "languagesAtHome": "Languages at home",
@@ -228,5 +228,9 @@
   "emailRenew": {
     "heading": "Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>"
   },
-  "": "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} on pyytänyt sinua vahvistamaan nuorisojäsenyytensä. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä:<br /><br /><a href=\"https://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}\">https://jassari.test.kuva.hel.ninja/approve/{{ youth_profile.approval_token }}</a><br /><br /><i>Tämä viesti on lähetetty järjestelmistä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
+  "feedback": {
+    "giveFeedback": {
+      "label": "Give feedback of the Jässäri service"
+    }
+  }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -230,7 +230,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Give feedback of the Jässäri service"
+      "label": "Give feedback of the Jässäri service",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
     }
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -231,7 +231,7 @@
   "feedback": {
     "giveFeedback": {
       "label": "Give feedback of the Jässäri service",
-      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSfpPCeAdiT9pcMRazxqA9DW-mbqoN2kNwaV53XydjzHWdyFKw/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
     }
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -227,5 +227,10 @@
   },
   "emailRenew": {
     "heading": "Tevehdys {{ youth_profile.profile.first_name }}! Nuorisopalveluiden jäsenyytesi on vanhentumassa. Uusi jäsenyytesi helposti täällä https://jassari.hel.fi/  Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/ <br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/<br /><br /> <i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
+  },
+  "feedback": {
+    "giveFeedback": {
+      "label": "Anna palautetta Jässäri verkkopalvelusta"
+    }
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -230,7 +230,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Anna palautetta Jässäri verkkopalvelusta"
+      "label": "Anna palautetta Jässäri verkkopalvelusta",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
     }
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -226,5 +226,10 @@
   },
   "emailRenew": {
     "heading": "Hejsan {{ youth_profile.profile.first_name }}! Ditt medlemskap i ungdomstjänsterna håller på att gå ut. Det är enkelt att förnya medlemskapet här https://jassari.hel.fi/ <br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>"
+  },
+  "feedback": {
+    "giveFeedback": {
+      "label": "Ge respons om Jässäri tjänsten"
+    }
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -229,7 +229,8 @@
   },
   "feedback": {
     "giveFeedback": {
-      "label": "Ge respons om Jässäri tjänsten"
+      "label": "Ge respons om Jässäri tjänsten",
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
     }
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -230,7 +230,7 @@
   "feedback": {
     "giveFeedback": {
       "label": "Ge respons om Jässäri tjänsten",
-      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
+      "link": "https://docs.google.com/forms/d/e/1FAIpQLSf0mf1gIUZ-k768RkOdBQm3bjp6TCDWQa1Wc1r_3WiYbDXLAA/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
     }
   }
 }


### PR DESCRIPTION
## Description

Adds a temporary link into the membership information page that leads users to a feedback form.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-421](https://helsinkisolutionoffice.atlassian.net/browse/YM-421)

## How Has This Been Tested?

I've tested this locally by hand.

## Manual Testing Instructions for Reviewers

The current QA version of the profile API does not support this UI anymore so this is difficult to test. You'll have to use a local version of helsinki profile or mock some data locally.

## Screenshots

<img width="817" alt="Screenshot 2020-11-19 at 15 19 37" src="https://user-images.githubusercontent.com/9090689/99671950-71970a00-2a7b-11eb-9542-515dddaa5c75.png">

