### PR TITLE
YM-441 | Refetch name query on profile creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,87 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
+
 ## [1.2.1] - 2020-11-25
+
 ### Added
+
 - Temporary feedback link button in membership information page
 
 ### Changed
+
 - Use GitHub actions instead of Travis
 
 ## [1.2.0] - 2020-11-03
+
 ### Added
+
 - E2E tests for emails and approval view
 - E2E tests for modifying own information
 
 ### Changed
+
 - Using an expired or non-existing approval token now displays a nice message to the user.
 
 ### Fixed
+
 - Logging uninteresting error messages to Sentry
 
 ## [1.1.1] - 2020-10-07
+
 ### Added
+
 - e2e - tests for viewing own information
 
-### Fixed 
+### Fixed
+
 - Fixed issue with loading profile data after logging in
 
 ## [1.1.0] - 2020-10-05
+
 ### Added
+
 - Approvers can now control additional contact persons
 - e2e - tests for youth's registration form.
 
 ### Changed
+
 - Hide user menu and disable links to home page on approval form
 - Replaced Cypress with TestCafe
 - Default meta description
 
 ### Fixed
+
 - Non existent dates being silently transformed into existing dates
 
 ## [1.0.1] - 2020-08-31
+
 ### Fixed
+
 - Fixed issue where application would crash when entering `Profile information` page.
 
 ## [1.0.0] - 2020-08-28
+
 ### Changed
+
 - Form fields are now validated on blur
 - Profile creation and editing views are now divided into sections [#123](https://github.com/City-of-Helsinki/youth-membership-ui/pull/123)
 
 ### Added
+
 - Controls for additional contact persons
 - List of additional contact persons in membership details view
 
 ### Fixed
+
 - Authentication info text position
 - Hide spinners from birth day input on Firefox
 - Missing profile language in approval view

--- a/src/domain/youthProfile/hooks/useCreateProfiles.ts
+++ b/src/domain/youthProfile/hooks/useCreateProfiles.ts
@@ -50,7 +50,7 @@ const useCreateProfiles = ({ onError }: Options) => {
   ] = useMutation<AddServiceConnectionData, AddServiceConnectionVariables>(
     ADD_SERVICE_CONNECTION,
     {
-      refetchQueries: ['HasYouthProfile'],
+      refetchQueries: ['HasYouthProfile', 'NameQuery'],
       awaitRefetchQueries: true,
     }
   );


### PR DESCRIPTION
## Description
Previously the name query was not updated, which caused the user menu
to not receive the details of the newly created profile, which in turn
caused the link to the profile to go missing from the user menu.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-441](https://helsinkisolutionoffice.atlassian.net/browse/YM-441)

## How Has This Been Tested?
I've tested this manually by registering a new youth profile and asserting that the user menu updated after the creation of the new profile.

## Manual Testing Instructions for Reviewers

As a non-logged in user without a profile

1. Input birthdate
1. Click log in
1. Input details
1. Register
1. Expect your name to be visible in the top right menu
1. Expect to see a link to Helsinki profile when you toggle the menu open
