### PR TITLE
YM-444 | Fix failing browser test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Year dependent failing snapshot test
+- Browser test that would always fail until march
 
 ## [1.2.1] - 2020-11-25
 

--- a/browser-tests/loginView.ts
+++ b/browser-tests/loginView.ts
@@ -1,7 +1,8 @@
+import { format, subYears } from 'date-fns';
+
 import { loginSelector } from './pages/loginSelector';
 import { hasLength } from './utils/valueUtils';
 import { testURL } from './utils/settings';
-import { format, subYears } from 'date-fns';
 
 fixture('Open login page').page(testURL());
 
@@ -40,7 +41,7 @@ test('Test age restrictions', async t => {
 
   // User age is > 29
   // Note: Use selectText in between, this results previous values to be overwritten
-  await (await fillForm(t, '15', '03', AGE_US_OVER_MAX))
+  await (await fillForm(t, '01', '01', AGE_US_OVER_MAX))
     .expect(loginSelector.errorText.innerText)
     .eql('Jässäri is only for youths between 8-29 years.');
 


### PR DESCRIPTION
## Description

The test data created a user that will be over 29 years after march, but assumed them to be over 30 already.

As a dirty fix I just changed their birthday into 01.01. Another approach would have been to find out the date that an exactly 30-year-old would be, but I am not sure if that would have been much better, and it would have required more work to implement.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-444](https://helsinkisolutionoffice.atlassian.net/browse/YM-444)

## How Has This Been Tested?

I ran browser test against this branch: https://github.com/City-of-Helsinki/youth-membership-ui/actions/runs/482027598

## Manual Testing Instructions for Reviewers

Check that browser test have passed here: https://github.com/City-of-Helsinki/youth-membership-ui/actions/runs/482027598
