### PR TITLE
Chore | Fix failing snapshot test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
 
+### Fixed
+
+- Year dependent failing snapshot test
+
 ## [1.2.1] - 2020-11-25
 
 ### Added

--- a/src/domain/youthProfile/approve/__test__/ApproveYouthProfileForm.test.tsx
+++ b/src/domain/youthProfile/approve/__test__/ApproveYouthProfileForm.test.tsx
@@ -12,7 +12,7 @@ const defaultProps = {
   profile: {
     firstName: 'Teemu',
     lastName: 'Testaaja',
-    birthDate: '2006-01-01',
+    birthDate: `${format(subYears(new Date(), 14), 'yyyy')}-01-01`,
     address: 'Testikuja 55, 00100 Helsinki',
     addresses: ['Kymintie 43, 00100 Helsinki'],
     email: 'teemu.testaaja@test.fi',

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`matches snapshot 1`] = `
       "approverFirstName": "Ville",
       "approverLastName": "Vanhempi",
       "approverPhone": "05012345567",
-      "birthDate": "2006-01-01",
+      "birthDate": "2007-01-01",
       "email": "teemu.testaaja@test.fi",
       "firstName": "Teemu",
       "language": "FINNISH",
@@ -41,7 +41,7 @@ exports[`matches snapshot 1`] = `
         "approverFirstName": "Ville",
         "approverLastName": "Vanhempi",
         "approverPhone": "05012345567",
-        "birthDate": "2006-01-01",
+        "birthDate": "2007-01-01",
         "email": "teemu.testaaja@test.fi",
         "firstName": "Teemu",
         "language": "FINNISH",
@@ -465,7 +465,7 @@ exports[`matches snapshot 1`] = `
                 "Kymintie 43, 00100 Helsinki",
               ]
             }
-            birthDate="01.01.2006"
+            birthDate="01.01.2007"
             email="teemu.testaaja@test.fi"
             language="FINNISH"
             name="Teemu Testaaja"
@@ -498,7 +498,7 @@ exports[`matches snapshot 1`] = `
                 <LabeledValue
                   label="Syntymäpäivä"
                   noMargin={true}
-                  value="01.01.2006"
+                  value="01.01.2007"
                 >
                   <div
                     className="wrapper noMargin"
@@ -511,7 +511,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       className="value"
                     >
-                      01.01.2006
+                      01.01.2007
                     </span>
                   </div>
                 </LabeledValue>
@@ -1142,7 +1142,7 @@ exports[`matches snapshot 1`] = `
                                     "approverFirstName": "Ville",
                                     "approverLastName": "Vanhempi",
                                     "approverPhone": "05012345567",
-                                    "birthDate": "2006-01-01",
+                                    "birthDate": "2007-01-01",
                                     "email": "teemu.testaaja@test.fi",
                                     "firstName": "Teemu",
                                     "language": "FINNISH",
@@ -1188,7 +1188,7 @@ exports[`matches snapshot 1`] = `
                                     "approverFirstName": "Ville",
                                     "approverLastName": "Vanhempi",
                                     "approverPhone": "05012345567",
-                                    "birthDate": "2006-01-01",
+                                    "birthDate": "2007-01-01",
                                     "email": "teemu.testaaja@test.fi",
                                     "firstName": "Teemu",
                                     "language": "FINNISH",


### PR DESCRIPTION
## Description

After the year changed, the test data no longer represent an user of
the expected age. This is a quick fix that changes the user's birthday
so that they are the correct age.

The problem with this fix is that the snapshot test will break once the year changes again. The test should ideally be refactored so that it's not dependent on current time and would not break as time moves onwards.

## How Has This Been Tested?

`yarn test` passes without errors.

## Manual Testing Instructions for Reviewers

Ensure that CI tests pass.
