### PR TITLE
FIX | Forward ref in TextInput integration

### DIFF
--- a/src/common/components/textInput/TextInput.tsx
+++ b/src/common/components/textInput/TextInput.tsx
@@ -5,11 +5,17 @@ import styles from './textInput.module.css';
 
 // We add a class that's used to make input's behave better in grid
 // layouts.
-const TextInput = ({ className, ...rest }: TextInputProps) => (
-  <HDSTextInput
-    {...rest}
-    className={[styles.input, className].filter(item => item).join(' ')}
-  />
+const TextInput = React.forwardRef(
+  (
+    { className, ...rest }: TextInputProps,
+    ref: React.Ref<HTMLInputElement>
+  ) => (
+    <HDSTextInput
+      {...rest}
+      className={[styles.input, className].filter(item => item).join(' ')}
+      ref={ref}
+    />
+  )
 );
 
 export default TextInput;

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -873,7 +873,7 @@ exports[`matches snapshot 1`] = `
                               <Field
                                 name="approverFirstName"
                               >
-                                <TextInput
+                                <ForwardRef
                                   id="approverFirstName"
                                   invalid={false}
                                   labelText="Etunimi *"
@@ -932,7 +932,7 @@ exports[`matches snapshot 1`] = `
                                       </div>
                                     </kl>
                                   </ForwardRef>
-                                </TextInput>
+                                </ForwardRef>
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
@@ -943,7 +943,7 @@ exports[`matches snapshot 1`] = `
                               <Field
                                 name="approverLastName"
                               >
-                                <TextInput
+                                <ForwardRef
                                   id="approverLastName"
                                   invalid={false}
                                   labelText="Sukunimi *"
@@ -1002,7 +1002,7 @@ exports[`matches snapshot 1`] = `
                                       </div>
                                     </kl>
                                   </ForwardRef>
-                                </TextInput>
+                                </ForwardRef>
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
@@ -1014,7 +1014,7 @@ exports[`matches snapshot 1`] = `
                               <Field
                                 name="approverEmail"
                               >
-                                <TextInput
+                                <ForwardRef
                                   id="approverEmail"
                                   invalid={false}
                                   labelText="Sähköpostiosoite *"
@@ -1075,7 +1075,7 @@ exports[`matches snapshot 1`] = `
                                       </div>
                                     </kl>
                                   </ForwardRef>
-                                </TextInput>
+                                </ForwardRef>
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
@@ -1087,7 +1087,7 @@ exports[`matches snapshot 1`] = `
                               <Field
                                 name="approverPhone"
                               >
-                                <TextInput
+                                <ForwardRef
                                   id="approverPhone"
                                   invalid={false}
                                   labelText="Puhelinnumero *"
@@ -1148,7 +1148,7 @@ exports[`matches snapshot 1`] = `
                                       </div>
                                     </kl>
                                   </ForwardRef>
-                                </TextInput>
+                                </ForwardRef>
                               </Field>
                             </FormikTestInput>
                           </div>


### PR DESCRIPTION
## Description

The wrapper I added in #199 did not forward ref, which caused an error to be logged in the birthday input component.

## Manual Testing Instructions for Reviewers

1. Open the application without being logged in
2. Expect no ref error to be logged
