### PR TITLE
FIX | Fix incorrect error colour in DateInput

### DIFF
--- a/src/common/components/dateInput/DateInputGroup.tsx
+++ b/src/common/components/dateInput/DateInputGroup.tsx
@@ -15,11 +15,13 @@ interface Props {
 
 function DateGroup({ children, id = INPUT_GROUP_ID, label, error }: Props) {
   const isInvalid = Boolean(error);
+  const errorId = `${id}-error`;
 
   return (
     <div
       role="group"
       aria-labelledby={id}
+      aria-describedby={errorId}
       className={className({
         'hds-text-input': true,
         'hds-text-input--invalid': isInvalid,
@@ -27,7 +29,11 @@ function DateGroup({ children, id = INPUT_GROUP_ID, label, error }: Props) {
     >
       <DateInputLabel id={id}>{label}</DateInputLabel>
       {children}
-      <span className="hds-text-input__helper-text">{error}</span>
+      {isInvalid && (
+        <span id={errorId} className="hds-text-input__error-text">
+          {error}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/common/components/dateInput/DateInputGroup.tsx
+++ b/src/common/components/dateInput/DateInputGroup.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import className from 'classnames';
 import 'hds-core/lib/components/text-input/text-input.css';
 
 import DateInputLabel from './DateInputLabel';
@@ -22,10 +21,7 @@ function DateGroup({ children, id = INPUT_GROUP_ID, label, error }: Props) {
       role="group"
       aria-labelledby={id}
       aria-describedby={errorId}
-      className={className({
-        'hds-text-input': true,
-        'hds-text-input--invalid': isInvalid,
-      })}
+      className="hds-text-input"
     >
       <DateInputLabel id={id}>{label}</DateInputLabel>
       {children}


### PR DESCRIPTION
## Description

The hds-core package had changed the way in which it applies error states. This PR changes the DateInput component to use that approach.

## How Has This Been Tested?

I've tested this manually.

## Manual Testing Instructions for Reviewers

1. Input a date that causes an error
2. Expect to see an error message
