### PR TITLE
YM-404 | Fix duplicate cancel button while editing own information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Year dependent failing snapshot test
 - Browser test that would always fail until march
+- While editing own information, there was "duplicate" cancel button. 
 
 ## [1.2.1] - 2020-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Year dependent failing snapshot test
 - Browser test that would always fail until march
-- While editing own information, there was "duplicate" cancel button. 
+- Duplicate cancel button in information editing view
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/domain/youthProfile/form/YouthProfileForm.tsx
+++ b/src/domain/youthProfile/form/YouthProfileForm.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'hds-react';
 import { Form, Formik, FormikProps } from 'formik';
-import { Link } from 'react-router-dom';
 import { differenceInYears } from 'date-fns';
 
 import {
@@ -26,6 +25,7 @@ import YouthProfileBasicInformationFields from './YouthProfileBasicInformationFi
 import YouthProfileAdditionalInformationFields from './YouthProfileAdditionalInformationFields';
 import YouthProfileApproverFields from './YouthProfileApproverFields';
 import FormikFocusError from './FormikFocusError';
+import LinkButton from '../../../common/components/linkButton/LinkButton';
 import styles from './youthProfileForm.module.css';
 
 export type Values = {
@@ -165,11 +165,13 @@ function YouthProfileForm(componentProps: Props) {
                 </Button>
 
                 {componentProps.isEditing && (
-                  <Link to="/membership-details">
-                    <Button variant="secondary" className={styles.button}>
-                      {t('registration.cancel')}
-                    </Button>
-                  </Link>
+                  <LinkButton
+                    className={styles.button}
+                    path="/membership-details"
+                    component="Link"
+                    buttonText={t('registration.cancel')}
+                    variant="secondary"
+                  />
                 )}
               </div>
             </PageSection>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Replaced the `<Link> + <button>` combo with `LinkButton`, this removed excess button element.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
Duplicate elements would cause confusion to users with screen reader.

[YM-404](https://helsinkisolutionoffice.atlassian.net/browse/YM-404)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
Tested this manually with voice over + chrome.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
1. While using screen reader, navigate to "Edit own information page"
2. Move to cancel button
3. Expect button text to be read once