### PR TITLE
YM-399 | Fix links that don't warn when opening a new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Browser test that would always fail until march
 - Duplicate cancel button in information editing view
 - Fixed issue where pages didn't have unique titles.
+- [Accessibility] Links that did not warn when they opened in a new window
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/common/components/externalLink/ExternalLink.tsx
+++ b/src/common/components/externalLink/ExternalLink.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { IconLinkExternal } from 'hds-react';
+
+import styles from './externalLink.module.css';
+
+type Props = React.PropsWithChildren<{
+  href: string;
+  className?: string;
+}>;
+
+const ExternalLink = ({ href, children, className, ...rest }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...rest}
+      className={[styles.externalLink, className].join(' ')}
+    >
+      {children} <IconLinkExternal aria-label={t('externalLink.description')} />
+    </a>
+  );
+};
+
+export default ExternalLink;

--- a/src/common/components/externalLink/__tests__/ExternalLink.tests.js
+++ b/src/common/components/externalLink/__tests__/ExternalLink.tests.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { render } from '../../../test/testing-library';
+import ExternalLink from '../ExternalLink';
+
+const defaultProps = {
+  href: 'https://hel.fi',
+  children: 'Helsingin kaupunki',
+};
+const getWrapper = props =>
+  render(<ExternalLink {...defaultProps} {...props} />);
+
+describe('<ExternalLink />', () => {
+  it('renders correctly', () => {
+    expect(getWrapper().container).toMatchSnapshot();
+  });
+
+  it('should warn that it opens in a new window', () => {
+    const { getByLabelText } = getWrapper();
+
+    expect(getByLabelText('Aukeaa uuteen ikkunaan')).toBeInTheDocument();
+  });
+});

--- a/src/common/components/externalLink/__tests__/__snapshots__/ExternalLink.tests.js.snap
+++ b/src/common/components/externalLink/__tests__/__snapshots__/ExternalLink.tests.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ExternalLink /> renders correctly 1`] = `
+<div>
+  <a
+    class="externalLink "
+    href="https://hel.fi"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    Helsingin kaupunki
+     
+    <svg
+      aria-label="Aukeaa uuteen ikkunaan"
+      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="evenodd"
+      >
+        <path
+          d="M0 0h24v24H0z"
+        />
+        <path
+          d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+          fill="currentColor"
+        />
+      </g>
+    </svg>
+  </a>
+</div>
+`;

--- a/src/common/components/externalLink/externalLink.module.css
+++ b/src/common/components/externalLink/externalLink.module.css
@@ -1,0 +1,4 @@
+.externalLink {
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/common/components/layout/footer/Footer.tsx
+++ b/src/common/components/layout/footer/Footer.tsx
@@ -3,6 +3,7 @@ import { Koros } from 'hds-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import ExternalLink from '../../externalLink/ExternalLink';
 import HelsinkiLogo from '../../helsinkiLogo/HelsinkiLogo';
 import styles from './Footer.module.css';
 
@@ -28,14 +29,12 @@ function Footer() {
                 {t('footer.accessibility')}
               </Link>
             </span>
-            <a
+            <ExternalLink
               href={t('footer.feedbackLink')}
-              target="_blank"
-              rel="noopener noreferrer"
               className={styles.feedback}
             >
               {t('footer.feedback')}
-            </a>
+            </ExternalLink>
           </div>
         </div>
       </footer>

--- a/src/common/components/layout/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/common/components/layout/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -43,14 +43,12 @@ exports[`matches snapshot 1`] = `
             Saavutettavuusseloste
           </Link>
         </span>
-        <a
+        <ExternalLink
           className="feedback"
           href="https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/fi/yhteystiedot-ja-palaute/Anna+palautetta/"
-          rel="noopener noreferrer"
-          target="_blank"
         >
           Anna palautetta
-        </a>
+        </ExternalLink>
       </div>
     </div>
   </footer>

--- a/src/common/components/linkButton/LinkButton.tsx
+++ b/src/common/components/linkButton/LinkButton.tsx
@@ -25,7 +25,7 @@ function LinkButton({
   rel,
   iconRight,
 }: Props) {
-  const iconRightWithPadding = iconRight ? ` ${iconRight}` : '';
+  const iconRightWithPadding = iconRight ? <> {iconRight}</> : '';
 
   if (component === 'Link') {
     return (

--- a/src/common/components/linkButton/LinkButton.tsx
+++ b/src/common/components/linkButton/LinkButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
@@ -12,6 +12,7 @@ type Props = {
   variant: 'primary' | 'secondary' | 'supplementary';
   rel?: string;
   className?: string;
+  iconRight?: ReactNode;
 };
 
 function LinkButton({
@@ -22,7 +23,10 @@ function LinkButton({
   component,
   variant,
   rel,
+  iconRight,
 }: Props) {
+  const iconRightWithPadding = iconRight ? ` ${iconRight}` : '';
+
   if (component === 'Link') {
     return (
       <Link
@@ -30,6 +34,7 @@ function LinkButton({
         className={classNames(`hds-button hds-button--${variant}`, className)}
       >
         <span className="hds-button__label">{buttonText}</span>
+        {iconRightWithPadding}
       </Link>
     );
   }
@@ -42,6 +47,7 @@ function LinkButton({
       rel={rel}
     >
       <span className="hds-button__label">{buttonText}</span>
+      {iconRightWithPadding}
     </a>
   );
 }

--- a/src/common/components/termsField/TermsField.tsx
+++ b/src/common/components/termsField/TermsField.tsx
@@ -3,6 +3,7 @@ import { Checkbox, CheckboxProps } from 'hds-react';
 import { useField } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
 
+import ExternalLink from '../externalLink/ExternalLink';
 import styles from './termsField.module.css';
 
 type Props = {
@@ -26,26 +27,9 @@ function TermsField(props: Props) {
             <Trans
               i18nKey="approval.approveTerms"
               components={[
-                // These components receive content  in the
-                // translation definition.
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  href={t('registry.descriptionLink')}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />,
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  href={t('privacyPolicy.helsinkiProfileLink')}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />,
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  href={t('privacyPolicy.descriptionLink')}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />,
+                <ExternalLink href={t('registry.descriptionLink')} />,
+                <ExternalLink href={t('privacyPolicy.helsinkiProfileLink')} />,
+                <ExternalLink href={t('privacyPolicy.descriptionLink')} />,
               ]}
             />
           </span>

--- a/src/domain/auth/components/login/Login.module.css
+++ b/src/domain/auth/components/login/Login.module.css
@@ -39,7 +39,7 @@
   }
 
   .linkButtons {
-    width: 340px;
+    width: 360px;
   }
 }
 

--- a/src/domain/auth/components/login/Login.tsx
+++ b/src/domain/auth/components/login/Login.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { differenceInYears } from 'date-fns';
 import { connect, useSelector } from 'react-redux';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
-import { Button } from 'hds-react';
+import { Button, IconLinkExternal } from 'hds-react';
 
 import LinkButton from '../../../../common/components/linkButton/LinkButton';
 import Text from '../../../../common/components/text/Text';
@@ -82,6 +82,11 @@ function Login(props: Props) {
                 variant="primary"
                 target="_blank"
                 rel="noopener noreferrer"
+                iconRight={
+                  <IconLinkExternal
+                    aria-label={t('externalLink.description')}
+                  />
+                }
               />
               <LinkButton
                 className={styles.linkButtons}
@@ -89,6 +94,11 @@ function Login(props: Props) {
                 component="a"
                 buttonText={t('login.findNearestService')}
                 variant="primary"
+                iconRight={
+                  <IconLinkExternal
+                    aria-label={t('externalLink.description')}
+                  />
+                }
               />
 
               <Button

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -1333,20 +1333,14 @@ exports[`matches snapshot 1`] = `
                           <Trans
                             components={
                               Array [
-                                <a
+                                <ExternalLink
                                   href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
-                                  rel="noopener noreferrer"
-                                  target="_blank"
                                 />,
-                                <a
+                                <ExternalLink
                                   href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
-                                  rel="noopener noreferrer"
-                                  target="_blank"
                                 />,
-                                <a
+                                <ExternalLink
                                   href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
-                                  rel="noopener noreferrer"
-                                  target="_blank"
                                 />,
                               ]
                             }
@@ -1385,52 +1379,139 @@ exports[`matches snapshot 1`] = `
                             <Trans
                               components={
                                 Array [
-                                  <a
+                                  <ExternalLink
                                     href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
-                                    rel="noopener noreferrer"
-                                    target="_blank"
                                   />,
-                                  <a
+                                  <ExternalLink
                                     href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
-                                    rel="noopener noreferrer"
-                                    target="_blank"
                                   />,
-                                  <a
+                                  <ExternalLink
                                     href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
-                                    rel="noopener noreferrer"
-                                    target="_blank"
                                   />,
                                 ]
                               }
                               i18nKey="approval.approveTerms"
                             >
                               Olen tutustunut 
-                              <a
+                              <ExternalLink
                                 href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
                                 key="1"
-                                rel="noopener noreferrer"
-                                target="_blank"
                               >
-                                tämän palvelun rekisteriselosteeseen
-                              </a>
+                                <a
+                                  className="externalLink "
+                                  href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  tämän palvelun rekisteriselosteeseen
+                                   
+                                  <Component
+                                    aria-label="Aukeaa uuteen ikkunaan"
+                                  >
+                                    <svg
+                                      aria-label="Aukeaa uuteen ikkunaan"
+                                      className="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <g
+                                        fill="none"
+                                        fillRule="evenodd"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                        />
+                                        <path
+                                          d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+                                          fill="currentColor"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Component>
+                                </a>
+                              </ExternalLink>
                               , 
-                              <a
+                              <ExternalLink
                                 href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
                                 key="3"
-                                rel="noopener noreferrer"
-                                target="_blank"
                               >
-                                Helsinki-profiilin rekisteriselosteeseen
-                              </a>
+                                <a
+                                  className="externalLink "
+                                  href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  Helsinki-profiilin rekisteriselosteeseen
+                                   
+                                  <Component
+                                    aria-label="Aukeaa uuteen ikkunaan"
+                                  >
+                                    <svg
+                                      aria-label="Aukeaa uuteen ikkunaan"
+                                      className="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <g
+                                        fill="none"
+                                        fillRule="evenodd"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                        />
+                                        <path
+                                          d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+                                          fill="currentColor"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Component>
+                                </a>
+                              </ExternalLink>
                                ja 
-                              <a
+                              <ExternalLink
                                 href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
                                 key="5"
-                                rel="noopener noreferrer"
-                                target="_blank"
                               >
-                                kaupungin tietosuojakäytäntöön
-                              </a>
+                                <a
+                                  className="externalLink "
+                                  href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  kaupungin tietosuojakäytäntöön
+                                   
+                                  <Component
+                                    aria-label="Aukeaa uuteen ikkunaan"
+                                  >
+                                    <svg
+                                      aria-label="Aukeaa uuteen ikkunaan"
+                                      className="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                                      role="img"
+                                      style={Object {}}
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <g
+                                        fill="none"
+                                        fillRule="evenodd"
+                                      >
+                                        <path
+                                          d="M0 0h24v24H0z"
+                                        />
+                                        <path
+                                          d="M10 3v2H5v14h14v-5h2v7H3V3h7zm11 0v8h-2V6.413l-7 7.001L10.586 12l6.999-7H13V3h8z"
+                                          fill="currentColor"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </Component>
+                                </a>
+                              </ExternalLink>
                               . Minuun voidaan olla yhteydessä antamieni tietojen avulla.
                             </Trans>
                           </span>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -54,6 +54,9 @@
   "edit": {
     "pageTitle": "Edit own information"
   },
+  "externalLink": {
+    "description": "Opens in a new window"
+  },
   "footer": {
     "accessibility": "Accessibility document",
     "copyright": "City of Helsinki",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -54,6 +54,9 @@
   "edit": {
     "pageTitle": "Muokkaa omia tietoja"
   },
+  "externalLink": {
+    "description": "Aukeaa uuteen ikkunaan"
+  },
   "footer": {
     "accessibility": "Saavutettavuusseloste",
     "copyright": "Helsingin kaupunki",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -54,6 +54,9 @@
   "edit": {
     "pageTitle": "Redigera egen information"
   },
+  "externalLink": {
+    "description": "Öppnas i nytt fönster"
+  },
   "footer": {
     "accessibility": "Tillgänglighetsdokument",
     "copyright": "Helsingfors stad",


### PR DESCRIPTION
## Description

Replaces the links that open a new window with the "ExternalLink" component which includes an icon warning for visual users and a text warning for screen reader users.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-399](https://helsinkisolutionoffice.atlassian.net/browse/YM-399)

## How Has This Been Tested?

I've tested the feedback link and the links within the terms field manually with Safari and VoiceOver and I've added unit tests for the `ExternalLink` component.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Navigate to feedback link (footer area)
2. Expect to hear a warning about the link opening in a new tab

.

1. Navigate to user creation form
2. Expect all the links within the terms field label to warn that they open in a new tab

Note that labels containing links are not good for accessibility, but it's beyond the scope of this change.
