### PR TITLE
YM-403 | Inconsistent HTML headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Browser test that would always fail until march
 - Duplicate cancel button in information editing view
 - Fixed issue where pages didn't have unique titles.
+- Fixed the inconsistent use of HTML headings.
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -30,7 +30,7 @@ function MembershipInformation({
       {membershipInformationTypes && (
         <React.Fragment>
           <Text variant="h1">{getFullName(membershipInformationTypes)}</Text>
-          <Text variant="h3">
+          <Text variant="h2" className={styles.membershipNumber}>
             {t('membershipInformation.title', {
               number:
                 membershipInformationTypes?.myYouthProfile?.membershipNumber,

--- a/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
+++ b/src/domain/membership/information/__tests__/MembershipInformationPage.test.tsx
@@ -48,7 +48,7 @@ it('mocked data is found', async () => {
   await updateWrapper(wrapper);
 
   const name = wrapper.find('h1').text();
-  const membershipNumber = wrapper.find('h3').text();
+  const membershipNumber = wrapper.find('h2').text();
   const validUntil = wrapper.find('.validUntil').text();
 
   expect(name).toEqual('Teemu Testaaja');

--- a/src/domain/membership/information/membershipInformation.module.css
+++ b/src/domain/membership/information/membershipInformation.module.css
@@ -4,6 +4,10 @@
     align-items: center;
 }
 
+.membershipNumber {
+    font-size: var(--fontsize-heading-m);
+}
+
 .validUntil {
     margin-bottom: var(--spacing-m);
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Wen't through the application with Siteimprove extension and manually. There was only one page where to order of headings was incorrect.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
Inconsistent use of HTML headings make it difficult to navigate the application with screen reader.

[YM-403](https://helsinkisolutionoffice.atlassian.net/browse/YM-403)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
I tested this manually.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
Use extension like Siteimprove to help you. Manually check heading elements that they are in correct order.
