### PR TITLE
YM-396 | Fix cognitively challenging date input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Duplicate cancel button in information editing view
 - Fixed issue where pages didn't have unique titles.
 - [Accessibility] Links that did not warn when they opened in a new window
+- [Accessibility] Cognitively challenging date input
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/common/components/dateInput/DateInputLogic.tsx
+++ b/src/common/components/dateInput/DateInputLogic.tsx
@@ -14,12 +14,10 @@ const DATE_INPUT_ALLOWED_CHARACTERS = [
   '9',
 ];
 const INPUT_CONFIGS = {
-  // We are invoking type number in order to allow platforms invoke
-  // behavior that allows more convenient  number input.
-  type: 'number',
-  // Sets the minimum allowed number as 0 for chrome controls. The user
-  // is still able to input a negative number by hand if they choose.
-  min: 0,
+  // We are invoking type text in order to discourage platforms from
+  // applying spinners which may increase the cognitive load of the
+  // input.
+  type: 'text',
   // Forces the number keyboard on mobile devices
   inputMode: 'numeric',
   // 1) Ensures that a number pad is shown on iOS instead of the regular
@@ -40,7 +38,6 @@ export interface InputComponentProps {
   onChange: (event: React.FormEvent<HTMLInputElement>) => void;
   value?: string;
   innerRef?: React.RefObject<HTMLInputElement>;
-  min: number;
   pattern: string;
   type: string;
   isInvalid: boolean;


### PR DESCRIPTION
## Description

Using the number type would allow the arrow keys to be used in
selecting the content of a date part. This was however deemed too
confusing in the accessibility report.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-396](https://helsinkisolutionoffice.atlassian.net/browse/YM-396)

## How Has This Been Tested?

I've tested this manually by using Safari and VoiceOver. There is no longer a mention of a spinner field, nor do the arrow keys work.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Navigate to birthday input
2. Navigate through date input fields
3. Expect for fields to be described as text fields
4. Expect that up and down arrow don't change the value in the fields




