### PR TITLE
YM-397 | Use more descriptive error messages on forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Accessibility] Mobile menu that was unusable on mobile
 - [Accessibility] Misleading labels on logo and application name links
 - [Accessibility] Missing jump to content link
+- [Accessibility] Use more description error messages on forms
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/common/helpers/__tests__/yupErrorReconciler.test.js
+++ b/src/common/helpers/__tests__/yupErrorReconciler.test.js
@@ -1,0 +1,23 @@
+import yupErrorReconciler from '../yupErrorReconciler';
+
+describe('yupErrorReconciler', () => {
+  it('works with strings', () => {
+    const stringError = 'string-error';
+
+    expect(yupErrorReconciler(stringError)).toEqual([stringError]);
+  });
+
+  it('works with objects', () => {
+    const objectError = {
+      key: 'object-error-key',
+      values: {
+        label: 'fields.label',
+      },
+    };
+
+    expect(yupErrorReconciler(objectError)).toEqual([
+      objectError.key,
+      objectError.values,
+    ]);
+  });
+});

--- a/src/common/helpers/yupErrorReconciler.ts
+++ b/src/common/helpers/yupErrorReconciler.ts
@@ -1,0 +1,38 @@
+import i18n from 'i18next';
+import * as yup from 'yup';
+
+type Options = Partial<yup.TestMessageParams>;
+
+type ErrorWithTranslationOptions = {
+  key: string;
+  values: Record<string, string>;
+};
+
+function getTranslatedValues(values?: Options): Options | undefined {
+  if (!values) {
+    return;
+  }
+
+  if (!values.label) {
+    return values;
+  }
+
+  return {
+    ...values,
+    label: i18n.t(values.label),
+  };
+}
+
+function yupErrorReconciler(
+  error: ErrorWithTranslationOptions | string
+): [string, Options?] {
+  if (typeof error === 'string') {
+    return [error];
+  }
+
+  const translatedValues = getTranslatedValues(error.values);
+
+  return [error.key, translatedValues];
+}
+
+export default yupErrorReconciler;

--- a/src/domain/app/BrowserApp.tsx
+++ b/src/domain/app/BrowserApp.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 
-import App from './App';
+// i18n should be loaded before the application so that yup schemas are
+// ready before schemas are created
 import i18n from '../../i18n/i18nInit';
+import App from './App';
 
 function BrowserApp() {
   return (

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`matches snapshot 1`] = `
                   "_exclusive": Object {
                     "required": true,
                   },
+                  "_label": "fields.email",
                   "_mutate": undefined,
                   "_options": Object {
                     "abortEarly": true,
@@ -165,6 +166,7 @@ exports[`matches snapshot 1`] = `
                   "_exclusive": Object {
                     "required": true,
                   },
+                  "_label": "fields.firstName",
                   "_mutate": undefined,
                   "_options": Object {
                     "abortEarly": true,
@@ -193,6 +195,7 @@ exports[`matches snapshot 1`] = `
                   "_exclusive": Object {
                     "required": true,
                   },
+                  "_label": "fields.lastName",
                   "_mutate": undefined,
                   "_options": Object {
                     "abortEarly": true,
@@ -221,6 +224,7 @@ exports[`matches snapshot 1`] = `
                   "_exclusive": Object {
                     "required": true,
                   },
+                  "_label": "fields.phoneNumber",
                   "_mutate": undefined,
                   "_options": Object {
                     "abortEarly": true,
@@ -267,6 +271,7 @@ exports[`matches snapshot 1`] = `
               "required": true,
               "undefined": false,
             },
+            "_label": "fields.approverEmail",
             "_mutate": undefined,
             "_options": Object {
               "abortEarly": true,
@@ -298,6 +303,7 @@ exports[`matches snapshot 1`] = `
               "min": true,
               "required": true,
             },
+            "_label": "fields.firstName",
             "_mutate": undefined,
             "_options": Object {
               "abortEarly": true,
@@ -330,6 +336,7 @@ exports[`matches snapshot 1`] = `
               "min": true,
               "required": true,
             },
+            "_label": "fields.lastName",
             "_mutate": undefined,
             "_options": Object {
               "abortEarly": true,
@@ -361,6 +368,7 @@ exports[`matches snapshot 1`] = `
               "min": true,
               "required": true,
             },
+            "_label": "fields.phoneNumber",
             "_mutate": undefined,
             "_options": Object {
               "abortEarly": true,

--- a/src/domain/youthProfile/form/FormikTextInput.tsx
+++ b/src/domain/youthProfile/form/FormikTextInput.tsx
@@ -4,6 +4,7 @@ import { TextInputProps } from 'hds-react';
 import get from 'lodash/get';
 import { useTranslation } from 'react-i18next';
 
+import yupErrorReconciler from '../../../common/helpers/yupErrorReconciler';
 import TextInput from '../../../common/components/textInput/TextInput';
 
 type Props = TextInputProps;
@@ -14,7 +15,10 @@ function FormikTestInput(props: Props) {
   const getError = ({
     field,
     form,
-  }: FieldProps<string>): string | undefined => {
+  }: FieldProps<string>):
+    | string
+    | { key: string; values: Record<string, string> }
+    | undefined => {
     const fieldName = field.name;
 
     return get(form.errors, fieldName);
@@ -37,7 +41,7 @@ function FormikTestInput(props: Props) {
       return;
     }
 
-    return t(error);
+    return t(...yupErrorReconciler(error));
   };
 
   return (

--- a/src/domain/youthProfile/youthProfileSchemas.ts
+++ b/src/domain/youthProfile/youthProfileSchemas.ts
@@ -9,9 +9,7 @@ import ageConstants from './constants/ageConstants';
 
 const isConsentRequired = (birthDate: string, schema: Yup.StringSchema) => {
   const userAge = differenceInYears(new Date(), new Date(birthDate));
-  return userAge < ageConstants.ADULT
-    ? schema.required('validation.required')
-    : schema;
+  return userAge < ageConstants.ADULT ? schema.required() : schema;
 };
 
 const requireIfNotAdult = (extendedSchema: Yup.StringSchema) => {
@@ -23,40 +21,58 @@ const requireIfNotAdult = (extendedSchema: Yup.StringSchema) => {
 };
 
 const approverFirstNameSchema = Yup.string()
-  .min(2, 'validation.tooShort')
-  .max(255, 'validation.tooLong');
+  .min(2)
+  .max(255)
+  .label('fields.firstName');
 const approverLastNameSchema = Yup.string()
-  .min(2, 'validation.tooShort')
-  .max(255, 'validation.tooLong');
-const approverEmailSchema = Yup.string().email('validation.email');
-const approverPhoneSchema = Yup.string().min(6, 'validation.phoneMin');
+  .min(2)
+  .max(255)
+  .label('fields.lastName');
+const approverEmailSchema = Yup.string()
+  .email()
+  .label('fields.email');
+const approverPhoneSchema = Yup.string()
+  .min(6)
+  .label('fields.phoneNumber');
 
 const additionalContactPersonsSchema = Yup.array(
   Yup.object({
-    firstName: Yup.string().required('validation.required'),
-    lastName: Yup.string().required('validation.required'),
-    phone: Yup.string().required('validation.required'),
-    email: Yup.string().required('validation.required'),
+    firstName: Yup.string()
+      .required()
+      .label('fields.firstName'),
+    lastName: Yup.string()
+      .required()
+      .label('fields.lastName'),
+    phone: Yup.string()
+      .required()
+      .label('fields.phoneNumber'),
+    email: Yup.string()
+      .required()
+      .label('fields.email'),
   })
 );
 
 const basicInformationSchema = Yup.object().shape({
   firstName: Yup.string()
-    .min(2, 'validation.tooShort')
-    .max(255, 'validation.tooLong')
-    .required('validation.required'),
+    .min(2)
+    .max(255)
+    .required()
+    .label('fields.firstName'),
   lastName: Yup.string()
-    .min(2, 'validation.tooShort')
-    .max(255, 'validation.tooLong')
-    .required('validation.required'),
+    .min(2)
+    .max(255)
+    .required()
+    .label('fields.lastName'),
   primaryAddress: Yup.object().shape({
     address: Yup.string()
-      .min(2, 'validation.tooShort')
-      .max(255, 'validation.tooLong')
-      .required('validation.required'),
+      .min(2)
+      .max(255)
+      .required()
+      .label('fields.streetAddress'),
     postalCode: Yup.mixed()
-      .required('validation.required')
-      .test('isValidPostalCode', 'validation.invalidValue', function() {
+      .required()
+      .label('fields.postalCode')
+      .test('isValidPostalCode', 'validation.invalidPostalCode', function() {
         if (postcodeValidatorExistsForCountry(this.parent.countryCode)) {
           return postcodeValidator(
             this.parent.postalCode,
@@ -66,18 +82,19 @@ const basicInformationSchema = Yup.object().shape({
         return this.parent?.postalCode?.length < 32;
       }),
     city: Yup.string()
-      .min(2, 'validation.tooShort')
-      .max(255, 'validation.tooLong')
-      .required('validation.required'),
+      .min(2)
+      .max(255)
+      .required()
+      .label('fields.city'),
   }),
   addresses: Yup.array().of(
     Yup.object().shape({
       address: Yup.string()
-        .min(2, 'validation.tooShort')
-        .max(255, 'validation.tooLong'),
+        .min(2)
+        .max(255),
       postalCode: Yup.mixed().test(
         'isValidPostalCode',
-        'validation.invalidValue',
+        'validation.invalidPostalCode',
         function() {
           if (postcodeValidatorExistsForCountry(this.parent.countryCode)) {
             return postcodeValidator(
@@ -89,19 +106,26 @@ const basicInformationSchema = Yup.object().shape({
         }
       ),
       city: Yup.string()
-        .min(2, 'validation.tooShort')
-        .max(255, 'validation.tooLong'),
+        .min(2)
+        .max(255),
     })
   ),
   phone: Yup.string()
-    .min(6, 'validation.phoneMin')
-    .required('validation.required'),
+    .min(6)
+    .required()
+    .label('fields.phoneNumber'),
 });
 
 const additionalInformationSchema = Yup.object().shape({
-  schoolName: Yup.string().max(128, 'validation.tooLong'),
-  schoolClass: Yup.string().max(10, 'validation.tooLong'),
-  photoUsageApproved: Yup.string().required('validation.required'),
+  schoolName: Yup.string()
+    .max(128)
+    .label('fields.schoolName'),
+  schoolClass: Yup.string()
+    .max(10)
+    .label('fields.schoolClass'),
+  photoUsageApproved: Yup.string()
+    .required()
+    .label('fields.photoUsageApproved'),
 });
 
 const youthApproverSchema = Yup.object().shape({
@@ -113,15 +137,17 @@ const youthApproverSchema = Yup.object().shape({
 });
 
 const guardianApproverSchema = Yup.object().shape({
-  approverFirstName: approverFirstNameSchema.required('validation.required'),
-  approverLastName: approverLastNameSchema.required('validation.required'),
-  approverEmail: approverEmailSchema.required('validation.required'),
-  phone: approverPhoneSchema.required('validation.required'),
+  approverFirstName: approverFirstNameSchema
+    .required()
+    .label('fields.firstName'),
+  approverLastName: approverLastNameSchema.required().label('fields.lastName'),
+  approverEmail: approverEmailSchema.required().label('fields.approverEmail'),
+  phone: approverPhoneSchema.required().label('fields.phoneNumber'),
   additionalContactPersons: additionalContactPersonsSchema,
 });
 
 const termsSchema = Yup.object().shape({
-  terms: Yup.boolean().oneOf([true], 'validation.required'),
+  terms: Yup.boolean().oneOf([true], 'validation.requiredTerms'),
 });
 
 export const approveYouthProfileFormSchema = guardianApproverSchema.concat(

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -249,7 +249,7 @@
   "fields": {
     "firstName": "a first name",
     "lastName": "a last name",
-    "streetAddress": "a streer address",
+    "streetAddress": "a street address",
     "postalCode": "a postal code",
     "city": "a city",
     "phoneNumber": "a phone number",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -212,12 +212,11 @@
     "updated": "Updated 20.1.2020"
   },
   "validation": {
-    "email": "Invalid email",
-    "invalidValue": "Invalid value",
-    "phoneMin": "Min length six characters",
-    "required": "Required",
-    "tooLong": "Too long",
-    "tooShort": "Too short"
+    "email": "Please enter a valid email address",
+    "invalidPostalCode": "Please enter a valid postal code",
+    "required": "Please enter {{label}}",
+    "tooLong": "Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "Please enter {{label}} that's more than {{min}} characters long"
   },
   "youthProfile": {
     "approverEmail": "Email",
@@ -245,5 +244,17 @@
       "label": "Give feedback of the Jässäri service",
       "link": "https://docs.google.com/forms/d/e/1FAIpQLSfpPCeAdiT9pcMRazxqA9DW-mbqoN2kNwaV53XydjzHWdyFKw/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
     }
+  },
+  "fields": {
+    "firstName": "a first name",
+    "lastName": "a last name",
+    "streetAddress": "a streer address",
+    "postalCode": "a postal code",
+    "city": "a city",
+    "phoneNumber": "a phone number",
+    "email": "an email",
+    "schoolName": "a school name",
+    "schoolClass": "a school class",
+    "photoUsageApproved": "photo usage approval"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -214,6 +214,7 @@
   "validation": {
     "email": "Please enter a valid email address",
     "invalidPostalCode": "Please enter a valid postal code",
+    "requiredTerms": "Please accept the terms",
     "required": "Please enter {{label}}",
     "tooLong": "Please enter {{label}} that's less than {{max}} characters long",
     "tooShort": "Please enter {{label}} that's more than {{min}} characters long"

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -212,12 +212,12 @@
     "updated": "Pävitetty viimeksi 20.1.2020"
   },
   "validation": {
-    "email": "Virheellinen sähköpostiosoite",
-    "invalidValue": "Virheellinen arvo",
-    "phoneMin": "Vähimmäispituus kuusi merkkiä",
-    "required": "Vaadittu",
-    "tooLong": "Liian pitkä",
-    "tooShort": "Liian lyhyt"
+    "email": "Täytyä toimiva sähköpostiosoite",
+    "invalidPostalCode": "Täytä oikea postinumero",
+    "requiredTerms": "Hyväksy ehdot",
+    "required": "Täytä {{label}}",
+    "tooLong": "Täytä {{label}}, joka on korkeintaan {{max}} merkkiä",
+    "tooShort": "Täytä {{label}}, joka on vähintään {{min}} merkkiä"
   },
   "youthProfile": {
     "approverEmail": "Sähköposti",
@@ -245,5 +245,17 @@
       "label": "Anna palautetta Jässäri verkkopalvelusta",
       "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
     }
+  },
+  "fields": {
+    "firstName": "etunimi",
+    "lastName": "sukunimi",
+    "streetAddress": "katuosoite",
+    "postalCode": "postinumero",
+    "city": "kaupunki",
+    "phoneNumber": "puhelinnumero",
+    "email": "sähköpostiosoite",
+    "schoolName": "koulun nimi",
+    "schoolClass": "luokka",
+    "photoUsageApproved": "kuvauslupa"
   }
 }

--- a/src/i18n/i18nInit.ts
+++ b/src/i18n/i18nInit.ts
@@ -5,6 +5,7 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import en from './en.json';
 import fi from './fi.json';
 import sv from './sv.json';
+import setYupLocale from './setYupLocale';
 
 i18n
   .use(LanguageDetector)
@@ -30,5 +31,7 @@ i18n
       caches: ['localStorage', 'cookie'],
     },
   });
+
+setYupLocale();
 
 export default i18n;

--- a/src/i18n/setYupLocale.ts
+++ b/src/i18n/setYupLocale.ts
@@ -1,0 +1,27 @@
+import * as yup from 'yup';
+
+function setYupLocale() {
+  yup.setLocale({
+    mixed: {
+      required: (options: Partial<yup.TestMessageParams>) => ({
+        key: 'validation.required',
+        values: options,
+      }),
+    },
+    string: {
+      min: (options: Partial<yup.TestMessageParams>) => ({
+        key: 'validation.tooShort',
+        values: options,
+      }),
+      max: (options: Partial<yup.TestMessageParams>) => ({
+        key: 'validation.tooLong',
+        values: options,
+      }),
+      email: () => ({
+        key: 'validation.email',
+      }),
+    },
+  });
+}
+
+export default setYupLocale;

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -212,12 +212,12 @@
     "updated": "Uppdaterad 20.1.2020"
   },
   "validation": {
-    "email": "Ogiltig e-postadress",
-    "invalidValue": "Ogiltigt värde",
-    "phoneMin": "Minst sex tecken",
-    "required": "Nödvändig",
-    "tooLong": "För lång",
-    "tooShort": "För kort"
+    "email": "Ange en giltig e-postadress",
+    "invalidPostalCode": "Fyll i ett giltigt postnummer",
+    "requiredTerms": "Godkänn villkoren",
+    "required": "Fyll i {{label}}",
+    "tooLong": "Fyll i {{label}} som är mindre än {{max}} tecken långt",
+    "tooShort": "Fyll i {{label}} som är mer än {{min}} tecken långt"
   },
   "youthProfile": {
     "approverEmail": "Epost",
@@ -244,5 +244,17 @@
       "label": "Ge respons om Jässäri tjänsten",
       "link": "https://docs.google.com/forms/d/e/1FAIpQLSf0mf1gIUZ-k768RkOdBQm3bjp6TCDWQa1Wc1r_3WiYbDXLAA/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
     }
+  },
+  "fields": {
+    "firstName": "ett förnamn",
+    "lastName": "ett efternamn",
+    "streetAddress": "en gatuadress",
+    "postalCode": "ett postnummer",
+    "city": "en stad",
+    "phoneNumber": "ett telefonnummer",
+    "email": "en e-postadress",
+    "schoolName": "ett skolnamn",
+    "schoolClass": "en skolklass",
+    "photoUsageApproved": "tillstånd för fotografering"
   }
 }


### PR DESCRIPTION
## Description

Adds more descriptive error messages to forms which contain more details about what actions the user needs to take to remedy the situation.

Building on the previous assumptions, I attempted to create generic error messages that can be shared between fields. The upside is that there are fewer translation strings to maintain and fewer changes in the code, but the downside is that this approach entangles the translations with the code some more.

I would generally advise to use non-generic strings when the translation require more convoluted structures. I've applied field specific errors for instance to the email field.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-397](https://helsinkisolutionoffice.atlassian.net/browse/YM-397)

## How Has This Been Tested?

I've tested this manually by going though the registration flow. I've added unit test to a new utility I added.

## Manual Testing Instructions for Reviewers

1. Go to edit information view
2. Test that three required fields get proper errors
3. Test that the first name field gives an error if you only input one character
4. Test that the school name gives an error if you input more than 10 characters
5. Test that the email field returns an error if you input an invalid email
6. Test that the postal code field returns an error when you input an invalid postal code


