### PR TITLE
YM-395 | Allow form fields to be autocompleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Accessibility] Links that did not warn when they opened in a new window
 - [Accessibility] Cognitively challenging date input
 - [Accessibility] Fixed the inconsistent use of HTML headings.
+- [Accessibility] Add support for autocomplete to form fields
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/common/components/dateInput/DateInput.tsx
+++ b/src/common/components/dateInput/DateInput.tsx
@@ -81,6 +81,9 @@ interface Props {
   dateInputLabel: string;
   monthInputLabel: string;
   yearInputLabel: string;
+  dateInputAutoComplete?: string;
+  monthInputAutoComplete?: string;
+  yearInputAutoComplete?: string;
 }
 
 function DateInput({
@@ -102,6 +105,9 @@ function DateInput({
   dateInputLabel,
   monthInputLabel,
   yearInputLabel,
+  dateInputAutoComplete,
+  monthInputAutoComplete,
+  yearInputAutoComplete,
 }: Props) {
   return (
     <DateInputGroup label={label} error={error}>
@@ -124,6 +130,9 @@ function DateInput({
         dateInputLabel={dateInputLabel}
         monthInputLabel={monthInputLabel}
         yearInputLabel={yearInputLabel}
+        dateInputAutoComplete={dateInputAutoComplete}
+        monthInputAutoComplete={monthInputAutoComplete}
+        yearInputAutoComplete={yearInputAutoComplete}
       />
     </DateInputGroup>
   );

--- a/src/common/components/dateInput/DateInputLogic.tsx
+++ b/src/common/components/dateInput/DateInputLogic.tsx
@@ -42,6 +42,7 @@ export interface InputComponentProps {
   type: string;
   isInvalid: boolean;
   label: string;
+  autoComplete?: string;
 }
 
 export interface WrapperComponentProps {
@@ -74,6 +75,9 @@ interface Props {
   dateInputLabel: string;
   monthInputLabel: string;
   yearInputLabel: string;
+  dateInputAutoComplete?: string;
+  monthInputAutoComplete?: string;
+  yearInputAutoComplete?: string;
 }
 
 function formatDateComponent(dateComponent: string): string {
@@ -186,6 +190,9 @@ function DateInputLogic({
   dateInputLabel,
   monthInputLabel,
   yearInputLabel,
+  dateInputAutoComplete,
+  monthInputAutoComplete,
+  yearInputAutoComplete,
 }: Props) {
   const externalDate = getDateComponents(value);
   const [internalDate, setInternalDate] = React.useState<DateObject>(
@@ -269,6 +276,7 @@ function DateInputLogic({
       onChange: handleDayOfMonthChange,
       isInvalid,
       label: dateInputLabel,
+      autoComplete: dateInputAutoComplete,
       ...INPUT_CONFIGS,
     }),
     React.createElement(monthComponent, {
@@ -280,6 +288,7 @@ function DateInputLogic({
       innerRef: monthInputRef,
       isInvalid,
       label: monthInputLabel,
+      autoComplete: monthInputAutoComplete,
       ...INPUT_CONFIGS,
     }),
     React.createElement(yearComponent, {
@@ -291,6 +300,7 @@ function DateInputLogic({
       innerRef: yearInputRef,
       isInvalid,
       label: yearInputLabel,
+      autoComplete: yearInputAutoComplete,
       ...INPUT_CONFIGS,
     }),
   ]);

--- a/src/domain/auth/components/birthdateForm/BirthdateForm.tsx
+++ b/src/domain/auth/components/birthdateForm/BirthdateForm.tsx
@@ -110,9 +110,11 @@ function BirthdateForm(props: Props) {
             dateInputLabel={t('registration.date')}
             monthInputLabel={t('registration.month')}
             yearInputLabel={t('registration.year')}
-            // Sets name in a way which allows auto-fill to set these
-            // values in case they are available. This makes the form
-            // more accessible.
+            // Allows for auto-fill to set these values in case they
+            // are available. This makes the form more accessible.
+            dateInputAutoComplete="bday-day"
+            monthInputAutoComplete="bday-month"
+            yearInputAutoComplete="bday-year"
             dateInputName="bday-day"
             monthInputName="bday-month"
             yearInputName="bday-year"

--- a/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfileForm.tsx
@@ -148,6 +148,7 @@ function ApproveYouthProfileForm(props: Props) {
                   additionalContactPersonHelperText={t(
                     'approval.addGuardianText'
                   )}
+                  viewer="approver"
                 />
               </div>
               <TermsField id="terms" name="terms" />

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -854,6 +854,7 @@ exports[`matches snapshot 1`] = `
                   </Text>
                   <YouthProfileApproverFields
                     additionalContactPersonHelperText="Muihin ilmoitettuihin huoltajiin voidaan olla yhteydessä lasta koskevissa asioissa."
+                    viewer="approver"
                   >
                     <Stack
                       space="xl"
@@ -866,6 +867,7 @@ exports[`matches snapshot 1`] = `
                             className="formGrid vertical-default"
                           >
                             <FormikTestInput
+                              autoComplete="given-name"
                               id="approverFirstName"
                               labelText="Etunimi *"
                               name="approverFirstName"
@@ -874,6 +876,7 @@ exports[`matches snapshot 1`] = `
                                 name="approverFirstName"
                               >
                                 <ForwardRef
+                                  autoComplete="given-name"
                                   id="approverFirstName"
                                   invalid={false}
                                   labelText="Etunimi *"
@@ -883,6 +886,7 @@ exports[`matches snapshot 1`] = `
                                   value="Ville"
                                 >
                                   <ForwardRef
+                                    autoComplete="given-name"
                                     className="input"
                                     id="approverFirstName"
                                     invalid={false}
@@ -919,6 +923,7 @@ exports[`matches snapshot 1`] = `
                                         >
                                           <input
                                             aria-describedby={null}
+                                            autoComplete="given-name"
                                             className="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
                                             disabled={false}
                                             id="approverFirstName"
@@ -936,6 +941,7 @@ exports[`matches snapshot 1`] = `
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
+                              autoComplete="family-name"
                               id="approverLastName"
                               labelText="Sukunimi *"
                               name="approverLastName"
@@ -944,6 +950,7 @@ exports[`matches snapshot 1`] = `
                                 name="approverLastName"
                               >
                                 <ForwardRef
+                                  autoComplete="family-name"
                                   id="approverLastName"
                                   invalid={false}
                                   labelText="Sukunimi *"
@@ -953,6 +960,7 @@ exports[`matches snapshot 1`] = `
                                   value="Vanhempi"
                                 >
                                   <ForwardRef
+                                    autoComplete="family-name"
                                     className="input"
                                     id="approverLastName"
                                     invalid={false}
@@ -989,6 +997,7 @@ exports[`matches snapshot 1`] = `
                                         >
                                           <input
                                             aria-describedby={null}
+                                            autoComplete="family-name"
                                             className="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
                                             disabled={false}
                                             id="approverLastName"
@@ -1006,6 +1015,7 @@ exports[`matches snapshot 1`] = `
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
+                              autoComplete="email"
                               id="approverEmail"
                               labelText="Sähköpostiosoite *"
                               name="approverEmail"
@@ -1015,6 +1025,7 @@ exports[`matches snapshot 1`] = `
                                 name="approverEmail"
                               >
                                 <ForwardRef
+                                  autoComplete="email"
                                   id="approverEmail"
                                   invalid={false}
                                   labelText="Sähköpostiosoite *"
@@ -1025,6 +1036,7 @@ exports[`matches snapshot 1`] = `
                                   value="ville.vanhempi@test.fi"
                                 >
                                   <ForwardRef
+                                    autoComplete="email"
                                     className="input"
                                     id="approverEmail"
                                     invalid={false}
@@ -1062,6 +1074,7 @@ exports[`matches snapshot 1`] = `
                                         >
                                           <input
                                             aria-describedby={null}
+                                            autoComplete="email"
                                             className="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
                                             disabled={false}
                                             id="approverEmail"
@@ -1079,6 +1092,7 @@ exports[`matches snapshot 1`] = `
                               </Field>
                             </FormikTestInput>
                             <FormikTestInput
+                              autoComplete="tel"
                               id="approverPhone"
                               labelText="Puhelinnumero *"
                               name="approverPhone"
@@ -1088,6 +1102,7 @@ exports[`matches snapshot 1`] = `
                                 name="approverPhone"
                               >
                                 <ForwardRef
+                                  autoComplete="tel"
                                   id="approverPhone"
                                   invalid={false}
                                   labelText="Puhelinnumero *"
@@ -1098,6 +1113,7 @@ exports[`matches snapshot 1`] = `
                                   value="05012345567"
                                 >
                                   <ForwardRef
+                                    autoComplete="tel"
                                     className="input"
                                     id="approverPhone"
                                     invalid={false}
@@ -1135,6 +1151,7 @@ exports[`matches snapshot 1`] = `
                                         >
                                           <input
                                             aria-describedby={null}
+                                            autoComplete="tel"
                                             className="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
                                             disabled={false}
                                             id="approverPhone"

--- a/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileApproverFields.tsx
@@ -11,11 +11,13 @@ import TextInput from './FormikTextInput';
 type Props = {
   isApproverFieldsRequired?: boolean;
   additionalContactPersonHelperText: string;
+  viewer?: 'youth' | 'approver';
 };
 
 function YouthProfileApproverFields({
   isApproverFieldsRequired = true,
   additionalContactPersonHelperText,
+  viewer = 'youth',
 }: Props) {
   const { t } = useTranslation();
 
@@ -32,6 +34,14 @@ function YouthProfileApproverFields({
     return t(translationPath);
   };
 
+  const getAutoComplete = (value: string): string | undefined => {
+    const isViewedByApprover = viewer === 'approver';
+
+    if (isViewedByApprover) {
+      return value;
+    }
+  };
+
   return (
     <Stack space="xl">
       <YouthProfileFormGrid>
@@ -39,23 +49,27 @@ function YouthProfileApproverFields({
           id="approverFirstName"
           name="approverFirstName"
           labelText={labelRequired('registration.firstName')}
+          autoComplete={getAutoComplete('given-name')}
         />
         <TextInput
           id="approverLastName"
           name="approverLastName"
           labelText={labelRequired('registration.lastName')}
+          autoComplete={getAutoComplete('family-name')}
         />
         <TextInput
           id="approverEmail"
           name="approverEmail"
           type="email"
           labelText={labelRequired('registration.email')}
+          autoComplete={getAutoComplete('email')}
         />
         <TextInput
           id="approverPhone"
           name="approverPhone"
           type="tel"
           labelText={labelRequired('registration.phoneNumber')}
+          autoComplete={getAutoComplete('tel')}
         />
       </YouthProfileFormGrid>
       <FormGroupDescription

--- a/src/domain/youthProfile/form/YouthProfileBasicInformationFields.tsx
+++ b/src/domain/youthProfile/form/YouthProfileBasicInformationFields.tsx
@@ -41,11 +41,13 @@ function YouthProfileFormBasicInformationFields({
           id="firstName"
           name="firstName"
           labelText={t('registration.firstName') + ' *'}
+          autoComplete="given-name"
         />
         <TextInput
           id="lastName"
           name="lastName"
           labelText={t('registration.lastName') + ' *'}
+          autoComplete="family-name"
         />
       </YouthProfileFormGrid>
       <Stack space="s">
@@ -58,6 +60,7 @@ function YouthProfileFormBasicInformationFields({
             type="select"
             options={countryOptions}
             labelText={t('registration.country')}
+            autoComplete="country-name"
           />
         </YouthProfileFormGrid>
         <YouthProfileAddressTemplate
@@ -66,6 +69,7 @@ function YouthProfileFormBasicInformationFields({
               id="primaryAddress.address"
               name="primaryAddress.address"
               labelText={t('registration.address') + ' *'}
+              autoComplete="address-line1"
             />
           }
           postalCode={
@@ -78,6 +82,7 @@ function YouthProfileFormBasicInformationFields({
                   : 'text'
               }
               labelText={t('registration.postalCode') + ' *'}
+              autoComplete="postal-code"
             />
           }
           city={
@@ -85,6 +90,7 @@ function YouthProfileFormBasicInformationFields({
               id="primaryAddress.city"
               name="primaryAddress.city"
               labelText={t('registration.city') + ' *'}
+              autoComplete="address-level2"
             />
           }
         />
@@ -174,6 +180,7 @@ function YouthProfileFormBasicInformationFields({
             { value: 'SWEDISH', label: t('LANGUAGE_OPTIONS.SWEDISH') },
           ]}
           labelText={t('registration.profileLanguage')}
+          autoComplete="language"
         />
         <Field
           as={TextInput}
@@ -182,12 +189,14 @@ function YouthProfileFormBasicInformationFields({
           type="text"
           labelText={t('registration.email')}
           readOnly
+          autoComplete="email"
         />
         <TextInput
           id="phone"
           name="phone"
           type="tel"
           labelText={t('registration.phoneNumber') + ' *'}
+          autoComplete="tel"
         />
       </YouthProfileFormGrid>
     </Stack>


### PR DESCRIPTION
## Description

By adding autocomplete attributes, we allow users to autocomplete or -fill form fields. This makes the forms more accessible, because it may be swifter for users to input values with autofill.

https://www.w3.org/TR/WCAG21/#input-purposes


## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-395](https://helsinkisolutionoffice.atlassian.net/browse/YM-395)

## How Has This Been Tested?

I've tested this manually by applying the attributes based on the resource linked above and checking that they can be found from elements.

## Manual Testing Instructions for Reviewers

I find this feature difficult to test, because it's unclear what logic browsers user to autofill fields. For instance Chrome would autofill fields correctly even without specifying these attributes.

In general terms, this procedure can be followed to check all the changes in case you are able to find a sandbox where you can test strictly autocomplete:

1. Navigate to login page
2. Expect birthday input to be autofillable with your birthday

.

1. Navigate to create/edit form
2. Expect your details (first name, last name, address fields, phone number, language) to be auto fillable
3. Expect approver fields not to be auto fillable

.

1. Navigate to approver field
2. Expect the approver fields to be auto fillable
