### PR TITLE
FIX | Change approver route to use AppPageTitleRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
 - Upgrade HDS from version 0.11.3 to 0.20.0
+- Approver route now uses AppPageTitleRoute
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
 - Upgrade HDS from version 0.11.3 to 0.20.0
-- Approver route now uses AppPageTitleRoute
 
 ### Fixed
 
@@ -26,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Accessibility] Misleading labels on logo and application name links
 - [Accessibility] Missing jump to content link
 - [Accessibility] Use more description error messages on forms
+- Fixed inaccessible approver route
 
 ## [1.2.1] - 2020-11-25
 

--- a/src/domain/app/AppRoutes.tsx
+++ b/src/domain/app/AppRoutes.tsx
@@ -21,7 +21,7 @@ function AppRoutes() {
       <Route path={['/approve/:approvalToken/:readToken']}>
         <PageLayout variant="approver">
           <Switch>
-            <AppYouthProfileRoute
+            <AppPageTitleRoute
               path="/approve/:approvalToken/:readToken"
               exact
               component={ApproveYouthProfilePage}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Changed approver route to use `AppPageTitleRoute` component. I forgot to change when reworking routing components.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

-

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
Tested this manually, route works.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->
- Have a profile that has pending confirmation and navigate to approval route. It should work normally.
