### PR TITLE
DEVOPS-228 - KuVa Tunnistamo to use

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,18 +19,19 @@ jobs:
     name: Build
     steps:
       - uses: actions/checkout@v2
+      - uses: andersinno/kolga-setup-action@v2
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'review'
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.test.kuva.hel.ninja/loginsso"
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso-test/"
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://api.hel.fi/auth/jassari"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.${{ env.BASE_DOMAIN }}/loginsso"
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://tunnistamo.${{ env.BASE_DOMAIN }}/"
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: ${{ env.K8S_NAMESPACE }}
           DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.test.kuva.hel.ninja/"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.${{ env.BASE_DOMAIN }}/"
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://$TF_PROJECT_NAME_SLUG-$CI_ENVIRONMENT_SLUG.$KUBE_INGRESS_BASE_DOMAIN"
-          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.test.kuva.hel.ninja/"
+          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.${{ env.BASE_DOMAIN }}/"
 
   review:
     runs-on: ubuntu-latest
@@ -45,3 +46,17 @@ jobs:
         env:
           ENVIRONMENT_URL: https://${{ env.K8S_NAMESPACE }}.${{ env.BASE_DOMAIN }}
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
+
+      - name: Setup Tunnistamo
+        uses: City-of-Helsinki/setup-tunnistamo-action@main
+        with:
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
+          review_namespace: ${{ env.K8S_NAMESPACE }}
+          api_scope: https://api.hel.fi/auth/jassariapi
+
+      - name: Setup Tunnistamo
+        uses: City-of-Helsinki/setup-tunnistamo-action@main
+        with:
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
+          review_namespace: ${{ env.K8S_NAMESPACE }}
+          api_scope: https://api.hel.fi/auth/helsinkiprofile

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,13 +26,13 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'staging'
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.test.kuva.hel.ninja/loginsso"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.${{ env.BASE_DOMAIN }}/loginsso"
           DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso-test/"
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://api.hel.fi/auth/jassari"
           DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.test.kuva.hel.ninja/"
-          DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari.test.kuva.hel.ninja"
-          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.test.kuva.hel.ninja/"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.${{ env.BASE_DOMAIN }}/"
+          DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari.${{ env.BASE_DOMAIN }}"
+          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.${{ env.BASE_DOMAIN }}/"
 
   staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Allows usage of Tunnistamo also at review environment(s)

## Context

[DEVOPS-228](https://helsinkisolutionoffice.atlassian.net/browse/DEVOPS-228)

## How Has This Been Tested?
Implemented to open-city-profile-ui, and tested also in created review env manually.

## Manual Testing Instructions for Reviewers
Access the review environment and sign in
