### PR TITLE
Chore | Use public Jassari API

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,13 +29,13 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.hel.fi/loginsso"
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://id.hel.fi/auth/clients/jassariui-prod"
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.prod.kuva.hel.ninja/"
-          DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari.hel.fi"
-          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.hel.fi/"
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.hel.fi/loginsso'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso/'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassariui-prod'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari.api.hel.fi'
+          DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari.hel.fi'
+          DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.hel.fi/'
 
   production:
     if: startsWith(github.ref, 'refs/tags')
@@ -55,4 +55,3 @@ jobs:
           ENVIRONMENT_URL: https://${{ secrets.ENVIRONMENT_URL_STABLE }}
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-production
           K8S_ADDITIONAL_HOSTNAMES: ${{ secrets.ADDITIONAL_HOSTNAMES }}
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,15 +10,15 @@ build-review:
   # These variables are available only for review env and are merged with the general variables defined above.
   extends: .build
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-review'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'review'
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.test.kuva.hel.ninja/loginsso"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso-test/"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://api.hel.fi/auth/jassari"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.test.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://$TF_PROJECT_NAME_SLUG-$CI_ENVIRONMENT_SLUG.$KUBE_INGRESS_BASE_DOMAIN"
-    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.test.kuva.hel.ninja/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.test.kuva.hel.ninja/loginsso'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso-test/'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/jassari'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari-federation.test.kuva.hel.ninja/'
+    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://$TF_PROJECT_NAME_SLUG-$CI_ENVIRONMENT_SLUG.$KUBE_INGRESS_BASE_DOMAIN'
+    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.test.kuva.hel.ninja/'
 
   only:
     refs:
@@ -27,15 +27,15 @@ build-review:
 build-staging:
   extends: .build
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'staging'
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.test.kuva.hel.ninja/loginsso"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso-test/"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://api.hel.fi/auth/jassari"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.test.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari.test.kuva.hel.ninja"
-    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.test.kuva.hel.ninja/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.test.kuva.hel.ninja/loginsso'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso-test/'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/jassari'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari-federation.test.kuva.hel.ninja/'
+    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari.test.kuva.hel.ninja'
+    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.test.kuva.hel.ninja/'
   only:
     refs:
       - develop
@@ -43,15 +43,15 @@ build-staging:
 build-production:
   extends: .build
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-production'
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: "https://profiili.hel.fi/loginsso"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://id.hel.fi/auth/clients/jassariui-prod"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: "openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile"
-    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://jassari-federation.prod.kuva.hel.ninja/"
-    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari.hel.fi"
-    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.hel.fi/"
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.hel.fi/loginsso'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso/'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassariui-prod'
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
+    DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari.api.hel.fi'
+    DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari.hel.fi'
+    DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.hel.fi/'
   only:
     refs:
       - master
@@ -60,17 +60,17 @@ build-production:
 
 review:
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-review'
     POSTGRES_ENABLED: 0
 
 # This will enable staging ci-pipeline
 staging:
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
   only:
     refs:
       - develop
 
 production:
   variables:
-    DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
+    DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-production'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
 - Upgrade HDS from version 0.11.3 to 0.20.0
+- Use public address for Jassari API
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Uses the public API for Jassari. The non-public endpoint may not be enabled for all users.
