### PR TITLE
FIX | Enable BASE_DOMAIN to fix incomplete urls

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,7 @@ env:
   KUBECONFIG_RAW: ${{ secrets.KUBECONFIG_RAW_STAGING }}
   BUILD_ARTIFACT_FOLDER: 'build_artifacts'
   SERVICE_ARTIFACT_FOLDER: 'service_artifacts'
+  BASE_DOMAIN: ${{ secrets.BASE_DOMAIN_STAGING }}
   SERVICE_PORT: 80
 
 jobs:


### PR DESCRIPTION
## Description

Enables `BASE_DOMAIN` environment variable for jobs so that complete urls can be built.
