### PR TITLE
YM-450 | Fix production build

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,8 +32,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.hel.fi/loginsso'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso/'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassariui-prod'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
-          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari.api.hel.fi'
+          DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://api.hel.fi/profiili/graphql/'
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari.hel.fi'
           DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.hel.fi/'
 


### PR DESCRIPTION
## Description

Downrgades the production build configuration so that we can rebuild
the current production version which assumes that Jässäri has not yet
been separated from Helsinki profile.

After merging these changes, we can re-release production and it'll be built with config that are compatible with its vurrent version.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-450](https://helsinkisolutionoffice.atlassian.net/browse/YM-450)
