### PR TITLE
Chore | Run browser tests against PR environment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,7 +36,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     needs: build
-    name: Review
+    name: Review and Accept
     steps:
       - uses: actions/checkout@v2
       - uses: andersinno/kolga-setup-action@v2
@@ -60,3 +60,48 @@ jobs:
           kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
           review_namespace: ${{ env.K8S_NAMESPACE }}
           api_scope: https://api.hel.fi/auth/helsinkiprofile
+
+      - name: Setup kubectl
+        run: |
+          echo "${{ env.KUBECONFIG_RAW }}" > $(pwd)/kubeconfig
+          echo "KUBECONFIG=$(pwd)/kubeconfig" >> $GITHUB_ENV
+        shell: bash
+      - name: Get Review Deploy URL
+        id: deploy-url
+        run: |
+          DEPLOY_URL=$(kubectl get ingress -n "${{ env.K8S_NAMESPACE }}" -o jsonpath='{.items[0].spec.rules[0].host}')
+          echo "BROWSER_TESTING_URL=https://$DEPLOY_URL" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 12.x
+      - name: Create yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline --frozen-lockfile --check-files
+
+      - name: Run Acceptance Tests
+        run: yarn browser-test:ci
+        env:
+          BROWSER_TESTING_MAILOSAUR_API: ${{ secrets.BROWSER_TESTING_MAILOSAUR_API }}
+          BROWSER_TESTING_MAILOSAUR_SERVER_ID: ${{ secrets.BROWSER_TESTING_MAILOSAUR_SERVER_ID }}
+          BROWSER_TESTING_USERNAME: ${{ secrets.BROWSER_TESTING_USERNAME }}
+          BROWSER_TESTING_USERNAME_WITH_PROFILE: ${{ secrets.BROWSER_TESTING_USERNAME_WITH_PROFILE }}
+          BROWSER_TESTING_USERNAME_NO_ACCESS: ${{ secrets.BROWSER_TESTING_USERNAME_NO_ACCESS }}
+          BROWSER_TESTING_PASSWORD: ${{ secrets.BROWSER_TESTING_PASSWORD }}
+      - name: Upload screenshots of failed tests
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: screenshots
+          path: screenshots/

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -53,6 +53,7 @@ jobs:
           kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
           review_namespace: ${{ env.K8S_NAMESPACE }}
           api_scope: https://api.hel.fi/auth/jassariapi
+          login_methods: github helusername
 
       - name: Setup Tunnistamo
         uses: City-of-Helsinki/setup-tunnistamo-action@main
@@ -60,6 +61,7 @@ jobs:
           kubeconfig_raw: ${{ env.KUBECONFIG_RAW}}
           review_namespace: ${{ env.K8S_NAMESPACE }}
           api_scope: https://api.hel.fi/auth/helsinkiprofile
+          login_methods: github helusername
 
       - name: Setup kubectl
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - User menu data is now updated after profile creation so that it will correctly show the name of the newly created profile
 - Upgrade HDS from version 0.11.3 to 0.20.0
 - Use public address for Jassari API
+- Run browser tests against PR environments
 
 ### Fixed
 

--- a/browser-tests/pages/loginSelector.ts
+++ b/browser-tests/pages/loginSelector.ts
@@ -11,4 +11,6 @@ export const loginSelector = {
   helUsername: Selector('#username'),
   helPassword: Selector('#password'),
   helLogin: Selector('#kc-login'),
+  permissionPage: Selector('h2').withText('Permission request'),
+  givePermissionButton: Selector('input[type="submit"][value="Allow"]'),
 };

--- a/browser-tests/utils/login.ts
+++ b/browser-tests/utils/login.ts
@@ -1,10 +1,19 @@
+import { format, subYears } from 'date-fns';
+
 import { loginSelector } from '../pages/loginSelector';
 import { username, password, usernameWithExistingProfile } from './settings';
-import { format, subYears } from 'date-fns';
 
 type UserAge = 'minor' | 'adult';
 const MINOR_YEAR = format(subYears(new Date(), 15), 'yyyy');
 const ADULT_YEAR = format(subYears(new Date(), 20), 'yyyy');
+
+const givePermission = async (t: TestController) => {
+  // If the user is show a permission request page
+  if (await loginSelector.permissionPage.exists) {
+    // Give permission
+    await t.click(loginSelector.givePermissionButton);
+  }
+};
 
 export const login = async (t: TestController, userAge: UserAge) => {
   await t
@@ -16,6 +25,8 @@ export const login = async (t: TestController, userAge: UserAge) => {
     .typeText(loginSelector.helUsername, username())
     .typeText(loginSelector.helPassword, password())
     .click(loginSelector.helLogin);
+
+  await givePermission(t);
 };
 
 export const loginStraight = async (t: TestController) => {
@@ -25,4 +36,6 @@ export const loginStraight = async (t: TestController) => {
     .typeText(loginSelector.helUsername, usernameWithExistingProfile())
     .typeText(loginSelector.helPassword, password())
     .click(loginSelector.helLogin);
+
+  await givePermission(t);
 };


### PR DESCRIPTION
## Description

Runs acceptance tests against PR environments when a PR is opened.

In order to accomplish this I copied the approach used in Tapahtumat Helsinki. I also had to change Tunnistamo configurations in order to enable Helsinki Tunnus as a means of authentication.

I changed the login routine to contain logic that enables the test routine to accept permissions requests if such is prompted.

## How Has This Been Tested?

The tests have been ran in this PR.

## Manual Testing Instructions for Reviewers

Check that the test pass.
