### PR TITLE
Hotfix YM-455 | Update privacy policy links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [1.2.5] - 2021-02-03
+### Changed
+- Fix privacy policy links
+
 ## [1.2.1] - 2020-11-25
 ### Added
 - Temporary feedback link button in membership information page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youth-membership-ui",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/src/common/components/layout/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/common/components/layout/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`matches snapshot 1`] = `
            
           <a
             className="links"
-            href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+            href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
           >
             Rekisteriseloste
           </a>

--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -696,143 +696,7 @@ exports[`matches snapshot 1`] = `
               <div
                 className="stack xl"
               >
-                <div>
-                  <Text
-                    variant="h2"
-                  >
-                    <h2
-                      className="text h2 "
-                    >
-                      Huoltajalta vaadittavat luvat
-                    </h2>
-                  </Text>
-                  <Text
-                    variant="h3"
-                  >
-                    <h3
-                      className="text h3 "
-                    >
-                      Kuvauslupa
-                    </h3>
-                  </Text>
-                  <Text
-                    variant="info"
-                  >
-                    <p
-                      className="text info "
-                    >
-                      Lapsesta voi ottaa kuvia ja niitä saa käyttää Helsingin kaupungin viestinnässä ja markkinoinnissa painetussa ja sähköisessä mediassa. Kuvaamisesta ja kuvien käytöstä ei makseta korvausta. Oikeus kuvien käyttöön on aina voimassa ja koskee koko Helsingin kaupungin viestintää ja markkinointiviestintää.
-                    </p>
-                  </Text>
-                  <div
-                    className="formFields"
-                  >
-                    <ul
-                      className="list"
-                    >
-                      <li
-                        className="radioButtonRow"
-                      >
-                        <Field
-                          as={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "render": [Function],
-                            }
-                          }
-                          checked={false}
-                          id="photoUsageApprovedYes"
-                          labelText="Kyllä"
-                          name="photoUsageApproved"
-                          value="true"
-                        >
-                          <ForwardRef
-                            checked={false}
-                            id="photoUsageApprovedYes"
-                            labelText="Kyllä"
-                            name="photoUsageApproved"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            value="true"
-                          >
-                            <div
-                              className="RadioButton-module_radioButton__cl9Gp radio-button_hds-radio-button__qM8AJ"
-                            >
-                              <input
-                                aria-checked={false}
-                                checked={false}
-                                className="RadioButton-module_input__3Jcdf radio-button_hds-radio-button__input__ztS8g"
-                                disabled={false}
-                                id="photoUsageApprovedYes"
-                                name="photoUsageApproved"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="radio"
-                                value="true"
-                              />
-                              <label
-                                className="RadioButton-module_label__g_pgE radio-button_hds-radio-button__label__1e-Rr"
-                                htmlFor="photoUsageApprovedYes"
-                              >
-                                Kyllä
-                              </label>
-                            </div>
-                          </ForwardRef>
-                        </Field>
-                      </li>
-                      <li
-                        className="radioButtonRow"
-                      >
-                        <Field
-                          as={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "render": [Function],
-                            }
-                          }
-                          checked={true}
-                          id="photoUsageApprovedNo"
-                          labelText="Ei"
-                          name="photoUsageApproved"
-                          value="false"
-                        >
-                          <ForwardRef
-                            checked={true}
-                            id="photoUsageApprovedNo"
-                            labelText="Ei"
-                            name="photoUsageApproved"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            value="false"
-                          >
-                            <div
-                              className="RadioButton-module_radioButton__cl9Gp radio-button_hds-radio-button__qM8AJ"
-                            >
-                              <input
-                                aria-checked={true}
-                                checked={true}
-                                className="RadioButton-module_input__3Jcdf radio-button_hds-radio-button__input__ztS8g"
-                                disabled={false}
-                                id="photoUsageApprovedNo"
-                                name="photoUsageApproved"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                type="radio"
-                                value="false"
-                              />
-                              <label
-                                className="RadioButton-module_label__g_pgE radio-button_hds-radio-button__label__1e-Rr"
-                                htmlFor="photoUsageApprovedNo"
-                              >
-                                Ei
-                              </label>
-                            </div>
-                          </ForwardRef>
-                        </Field>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
+                <div />
                 <div>
                   <Text
                     variant="h2"
@@ -1283,12 +1147,12 @@ exports[`matches snapshot 1`] = `
                             components={
                               Array [
                                 <a
-                                  href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+                                  href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 />,
                                 <a
-                                  href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                  href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
                                   rel="noopener noreferrer"
                                   target="_blank"
                                 />,
@@ -1335,12 +1199,12 @@ exports[`matches snapshot 1`] = `
                               components={
                                 Array [
                                   <a
-                                    href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+                                    href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   />,
                                   <a
-                                    href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                    href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                   />,
@@ -1355,7 +1219,7 @@ exports[`matches snapshot 1`] = `
                             >
                               Olen tutustunut 
                               <a
-                                href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+                                href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
                                 key="1"
                                 rel="noopener noreferrer"
                                 target="_blank"
@@ -1364,7 +1228,7 @@ exports[`matches snapshot 1`] = `
                               </a>
                               , 
                               <a
-                                href="https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+                                href="https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
                                 key="3"
                                 rel="noopener noreferrer"
                                 target="_blank"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -120,7 +120,7 @@
   },
   "privacyPolicy": {
     "descriptionLink": "https://www.hel.fi/helsinki/en/administration/information/data-protection",
-    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
   },
   "profile": {
     "address": "Address",
@@ -176,7 +176,7 @@
     "remove": "Delete"
   },
   "registry": {
-    "descriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+    "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
   },
   "sanityCheck": "youth-profile.en",
   "tos": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -120,7 +120,7 @@
   },
   "privacyPolicy": {
     "descriptionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/",
-    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
   },
   "profile": {
     "address": "Osoite",
@@ -176,7 +176,7 @@
     "remove": "Poista"
   },
   "registry": {
-    "descriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri.pdf"
+    "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
   },
   "sanityCheck": "youth-profile.fi",
   "tos": {

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -119,7 +119,7 @@
   },
   "privacyPolicy": {
     "descriptionLink": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd",
-    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Keha/Kanslia-EU-Sahkoisten-asiointipalveluiden-rekisteri.pdf"
+    "helsinkiProfileLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
   },
   "profile": {
     "address": "Adress",
@@ -176,7 +176,7 @@
   },
   "En begäran om dataverifiering skickas till föräldern och efter att dina uppgifter är granskade och godkända träder ditt medlemskap i kraft.": "",
   "registry": {
-    "descriptionLink": "https://www.hel.fi/static/liitteet/kanslia/rekisteriselosteet/Kuva/Kuva-EU-Nuorisopalvelujen-jasenrekisteri-SV.pdf"
+    "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Medlemsregister%20f%C3%B6r%20ungdomstj%C3%A4nsterna.pdf"
   },
   "sanityCheck": "youth-profile.sv",
   "tos": {


### PR DESCRIPTION
## Description

The privacy policy links have changed and the ones currently in use no longer lead to anywhere.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-455](https://helsinkisolutionoffice.atlassian.net/browse/YM-455)

## How Has This Been Tested?

I've checked that the links work by hand.

## Manual Testing Instructions for Reviewers

Check that the links are fixed in the footer and in the registration form.
