### PR TITLE
YM-439 | Fix gendered pronoun in approval confirmation view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Accessibility] Use more description error messages on forms
 - Fixed inaccessible approver route
 - Translation script running within docker development image
+- Gendered pronoun in approval confirmation view
 
 ## [1.2.5] - 2021-02-03
 
 ### Changed
+
 - Fix privacy policy links
 
 ## [1.2.4] - 2021-02-01

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,7 +20,7 @@
     "basicInfo": "Basic info",
     "birthDate": "Birthdate",
     "explanationError": "You have either already approved the application submitted by your youth or an error has occurred in our service.",
-    "explanationCheckStatus": "The youth can check his application status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationCheckStatus": "The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
     "formExplanationText_1": "has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
     "formExplanationText_2": "may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
     "languagesAtHome": "Languages at home",


### PR DESCRIPTION
## Description

Changes the English translation so that the approval view no longer contains inconsistent or gendered pronouns.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-439](https://helsinkisolutionoffice.atlassian.net/browse/YM-439)
