### PR TITLE
Release 1.3.2

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,7 +37,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_LINK: 'https://profiili.hel.fi/loginsso'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso/'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassariui-prod'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapi https://api.hel.fi/auth/helsinkiprofile'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid https://api.hel.fi/auth/jassariapiprod https://api.hel.fi/auth/helsinkiprofile'
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: 'https://jassari-federation.api.hel.fi/'
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari.hel.fi'
           DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: 'https://jassari-admin.hel.fi/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [1.3.2] - 2021-02-18
+
+### Fixed
+
+- Use correct API scope for youth membership
+
 ## [1.3.1] - 2021-02-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youth-membership-ui",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
`https://api.hel.fi/auth/jassariapiprod` should be used instead of `https://api.hel.fi/auth/jassariapi`