### PR TITLE
YM-466 | Fix photo usage always being set as true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Approval process always allowing photo usage regardless of choice
+
 ## [1.3.1] - 2021-02-18
 
 ### Fixed

--- a/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
+++ b/src/domain/youthProfile/approve/ApproveYouthProfilePage.tsx
@@ -42,7 +42,7 @@ function getApprovalData(
     approverEmail: values.approverEmail,
     approverPhone: values.approverPhone,
     birthDate: currentYouthProfile?.birthDate,
-    photoUsageApproved: Boolean(values.photoUsageApproved),
+    photoUsageApproved: values.photoUsageApproved === 'true',
     addAdditionalContactPersons: add,
     updateAdditionalContactPersons: update,
     removeAdditionalContactPersons: remove,


### PR DESCRIPTION
## Description

Fixes the photo usage approval boolean check.

It's a bit weird that a string value is used for the approval value, but I made the most minor change possible and just fixed the check.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-466](https://helsinkisolutionoffice.atlassian.net/browse/YM-466)

## Manual Testing Instructions for Reviewers

Ensure that >=15 && <18 year old can deny photo usage.
