### PR TITLE
YM-469 | Reflect membership status changes in membership info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Logic to handle the renewing membership status
+
 ### Fixed
 
 - Approval process always allowing photo usage regardless of choice

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,7 @@
+class Config {
+  static get adminUrl() {
+    return process.env.REACT_APP_ADMIN_URL;
+  }
+}
+
+export default Config;

--- a/src/domain/landingPage/LandingPage.tsx
+++ b/src/domain/landingPage/LandingPage.tsx
@@ -9,16 +9,28 @@ import SentYouthProfilePage from '../youthProfile/sent/SentYouthProfilePage';
 type MembershipStatusProps = {
   status: MembershipStatus;
   pending: ReactElement;
+  expired: ReactElement;
+  renewing: ReactElement;
   active: ReactElement;
 };
 
 function MemberShipStatusResolver({
   status,
   pending,
+  expired,
+  renewing,
   active,
 }: MembershipStatusProps) {
   if (status === MembershipStatus.PENDING) {
     return pending;
+  }
+
+  if (status === MembershipStatus.EXPIRED) {
+    return expired;
+  }
+
+  if (status === MembershipStatus.RENEWING) {
+    return renewing;
   }
 
   return active;
@@ -39,6 +51,8 @@ function LandingPage() {
     <MemberShipStatusResolver
       status={membershipStatus}
       pending={<SentYouthProfilePage />}
+      expired={<SentYouthProfilePage />}
+      renewing={<SentYouthProfilePage />}
       active={<MembershipInformationPage />}
     />
   );

--- a/src/domain/landingPage/LandingPage.tsx
+++ b/src/domain/landingPage/LandingPage.tsx
@@ -1,10 +1,28 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 import { MembershipStatus } from '../../graphql/generatedTypes';
 import toastNotification from '../../common/helpers/toastNotification/toastNotification';
 import MembershipInformationPage from '../membership/information/MembershipInformationPage';
 import useMembershipStatus from '../membership/useMembershipStatus';
 import SentYouthProfilePage from '../youthProfile/sent/SentYouthProfilePage';
+
+type MembershipStatusProps = {
+  status: MembershipStatus;
+  pending: ReactElement;
+  active: ReactElement;
+};
+
+function MemberShipStatusResolver({
+  status,
+  pending,
+  active,
+}: MembershipStatusProps) {
+  if (status === MembershipStatus.PENDING) {
+    return pending;
+  }
+
+  return active;
+}
 
 function LandingPage() {
   const [membershipStatus, loading] = useMembershipStatus({
@@ -13,19 +31,16 @@ function LandingPage() {
     },
   });
 
-  if (loading) {
+  if (loading || !membershipStatus) {
     return null;
   }
 
   return (
-    <>
-      {membershipStatus === MembershipStatus.PENDING && (
-        <SentYouthProfilePage />
-      )}
-      {membershipStatus !== MembershipStatus.PENDING && (
-        <MembershipInformationPage />
-      )}
-    </>
+    <MemberShipStatusResolver
+      status={membershipStatus}
+      pending={<SentYouthProfilePage />}
+      active={<MembershipInformationPage />}
+    />
   );
 }
 

--- a/src/domain/landingPage/LandingPage.tsx
+++ b/src/domain/landingPage/LandingPage.tsx
@@ -1,60 +1,30 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import { useQuery } from '@apollo/client';
+import { loader } from 'graphql.macro';
 
-import { MembershipStatus } from '../../graphql/generatedTypes';
 import toastNotification from '../../common/helpers/toastNotification/toastNotification';
 import MembershipInformationPage from '../membership/information/MembershipInformationPage';
-import useMembershipStatus from '../membership/useMembershipStatus';
 import SentYouthProfilePage from '../youthProfile/sent/SentYouthProfilePage';
 
-type MembershipStatusProps = {
-  status: MembershipStatus;
-  pending: ReactElement;
-  expired: ReactElement;
-  renewing: ReactElement;
-  active: ReactElement;
-};
-
-function MemberShipStatusResolver({
-  status,
-  pending,
-  expired,
-  renewing,
-  active,
-}: MembershipStatusProps) {
-  if (status === MembershipStatus.PENDING) {
-    return pending;
-  }
-
-  if (status === MembershipStatus.EXPIRED) {
-    return expired;
-  }
-
-  if (status === MembershipStatus.RENEWING) {
-    return renewing;
-  }
-
-  return active;
-}
+const APPROVED_TIME = loader('./YouthProfileApprovedTime.graphql');
 
 function LandingPage() {
-  const [membershipStatus, loading] = useMembershipStatus({
+  const { data, loading } = useQuery(APPROVED_TIME, {
     onError: () => {
       toastNotification();
     },
   });
 
-  if (loading || !membershipStatus) {
+  if (loading && !data) {
     return null;
   }
 
-  return (
-    <MemberShipStatusResolver
-      status={membershipStatus}
-      pending={<SentYouthProfilePage />}
-      expired={<SentYouthProfilePage />}
-      renewing={<SentYouthProfilePage />}
-      active={<MembershipInformationPage />}
-    />
+  const hasBeenApproved = data.myYouthProfile.approvedTime;
+
+  return hasBeenApproved ? (
+    <MembershipInformationPage />
+  ) : (
+    <SentYouthProfilePage />
   );
 }
 

--- a/src/domain/landingPage/LandingPage.tsx
+++ b/src/domain/landingPage/LandingPage.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import MembershipInformationPage from '../membership/information/MembershipInformationPage';
-import useIsMembershipPending from '../membership/useIsMembershipPending';
-import SentYouthProfilePage from '../youthProfile/sent/SentYouthProfilePage';
+import { MembershipStatus } from '../../graphql/generatedTypes';
 import toastNotification from '../../common/helpers/toastNotification/toastNotification';
+import MembershipInformationPage from '../membership/information/MembershipInformationPage';
+import useMembershipStatus from '../membership/useMembershipStatus';
+import SentYouthProfilePage from '../youthProfile/sent/SentYouthProfilePage';
 
 function LandingPage() {
-  const [isMembershipPending, loading] = useIsMembershipPending({
+  const [membershipStatus, loading] = useMembershipStatus({
     onError: () => {
       toastNotification();
     },
@@ -18,9 +19,10 @@ function LandingPage() {
 
   return (
     <>
-      {isMembershipPending ? (
+      {membershipStatus === MembershipStatus.PENDING && (
         <SentYouthProfilePage />
-      ) : (
+      )}
+      {membershipStatus !== MembershipStatus.PENDING && (
         <MembershipInformationPage />
       )}
     </>

--- a/src/domain/landingPage/YouthProfileApprovedTime.graphql
+++ b/src/domain/landingPage/YouthProfileApprovedTime.graphql
@@ -1,0 +1,6 @@
+query YouthProfileApprovedTime {
+  myYouthProfile {
+    id
+    approvedTime
+  }
+}

--- a/src/domain/membership/MembershipPageLayout.tsx
+++ b/src/domain/membership/MembershipPageLayout.tsx
@@ -1,0 +1,57 @@
+import React, { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import LinkButton from '../../common/components/linkButton/LinkButton';
+import Text from '../../common/components/text/Text';
+import styles from './membershipPageLayout.module.css';
+
+type Props = {
+  profileFullName: string;
+  membershipNumber: string;
+  membershipExpiryTitle: string;
+  membershipExpiryDescription?: string;
+  qrCode?: ReactElement;
+  mainActionButton?: ReactElement;
+  secondaryActionButton?: ReactElement;
+};
+
+function MembershipPageLayout({
+  profileFullName,
+  membershipNumber,
+  qrCode,
+  membershipExpiryTitle,
+  membershipExpiryDescription,
+  mainActionButton,
+  secondaryActionButton,
+}: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.container}>
+      <Text variant="h1">{profileFullName}</Text>
+      <Text variant="h2" className={styles.membershipNumber}>
+        {t('membershipInformation.title', {
+          number: membershipNumber,
+        })}
+      </Text>
+      {qrCode && qrCode}
+      <p className={styles.membershipExpiryTitle}>{membershipExpiryTitle}</p>
+      {membershipExpiryDescription && (
+        <p className={styles.membershipExpiryDescription}>
+          {membershipExpiryDescription}
+        </p>
+      )}
+      {mainActionButton && mainActionButton}
+      {secondaryActionButton && secondaryActionButton}
+      <LinkButton
+        className={styles.button}
+        path={t('feedback.giveFeedback.link')}
+        component="a"
+        buttonText={t('feedback.giveFeedback.label')}
+        variant="secondary"
+      />
+    </div>
+  );
+}
+
+export default MembershipPageLayout;

--- a/src/domain/membership/MembershipPageLayout.tsx
+++ b/src/domain/membership/MembershipPageLayout.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import LinkButton from '../../common/components/linkButton/LinkButton';
 import Text from '../../common/components/text/Text';
+import Stack from '../../common/components/stack/Stack';
 import styles from './membershipPageLayout.module.css';
 
 type Props = {
@@ -41,15 +42,16 @@ function MembershipPageLayout({
           {membershipExpiryDescription}
         </p>
       )}
-      {mainActionButton && mainActionButton}
-      {secondaryActionButton && secondaryActionButton}
-      <LinkButton
-        className={styles.button}
-        path={t('feedback.giveFeedback.link')}
-        component="a"
-        buttonText={t('feedback.giveFeedback.label')}
-        variant="secondary"
-      />
+      <Stack space="m">
+        {mainActionButton && mainActionButton}
+        {secondaryActionButton && secondaryActionButton}
+        <LinkButton
+          path={t('feedback.giveFeedback.link')}
+          component="a"
+          buttonText={t('feedback.giveFeedback.label')}
+          variant="secondary"
+        />
+      </Stack>
     </div>
   );
 }

--- a/src/domain/membership/MembershipPageLayout.tsx
+++ b/src/domain/membership/MembershipPageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import LinkButton from '../../common/components/linkButton/LinkButton';
@@ -9,8 +9,8 @@ import styles from './membershipPageLayout.module.css';
 type Props = {
   profileFullName: string;
   membershipNumber: string;
-  membershipExpiryTitle: string;
-  membershipExpiryDescription?: string;
+  membershipExpiryTitle: ReactNode;
+  membershipExpiryDescription?: ReactNode;
   qrCode?: ReactElement;
   mainActionButton?: ReactElement;
   secondaryActionButton?: ReactElement;
@@ -36,12 +36,14 @@ function MembershipPageLayout({
         })}
       </Text>
       {qrCode && qrCode}
-      <p className={styles.membershipExpiryTitle}>{membershipExpiryTitle}</p>
-      {membershipExpiryDescription && (
-        <p className={styles.membershipExpiryDescription}>
-          {membershipExpiryDescription}
-        </p>
-      )}
+      <section className={styles.membershipStatus}>
+        <p className={styles.membershipExpiryTitle}>{membershipExpiryTitle}</p>
+        {membershipExpiryDescription && (
+          <p className={styles.membershipExpiryDescription}>
+            {membershipExpiryDescription}
+          </p>
+        )}
+      </section>
       <Stack space="m">
         {mainActionButton && mainActionButton}
         {secondaryActionButton && secondaryActionButton}

--- a/src/domain/membership/MembershipUtility.ts
+++ b/src/domain/membership/MembershipUtility.ts
@@ -1,0 +1,25 @@
+import Config from '../../config';
+
+class Membership {
+  static getAdminUrl(profileId: null | string) {
+    const url = Config.adminUrl;
+
+    if (!profileId) {
+      return null;
+    }
+
+    return `${url}youthProfiles/${profileId}/show`;
+  }
+
+  static getFullName(profile: null | { firstName: string; lastName: string }) {
+    if (!profile) {
+      return '';
+    }
+
+    const { firstName, lastName } = profile;
+
+    return `${firstName} ${lastName}`.trim();
+  }
+}
+
+export default Membership;

--- a/src/domain/membership/MembershipUtility.ts
+++ b/src/domain/membership/MembershipUtility.ts
@@ -1,3 +1,7 @@
+import { differenceInYears } from 'date-fns';
+
+import { MembershipStatus } from '../../graphql/generatedTypes';
+import ageConstants from '../youthProfile/constants/ageConstants';
 import Config from '../../config';
 
 class Membership {
@@ -19,6 +23,30 @@ class Membership {
     const { firstName, lastName } = profile;
 
     return `${firstName} ${lastName}`.trim();
+  }
+
+  static getIsExpired(membershipStatus: MembershipStatus) {
+    return membershipStatus === MembershipStatus.EXPIRED;
+  }
+
+  static getIsActive(membershipStatus: MembershipStatus) {
+    return membershipStatus === MembershipStatus.ACTIVE;
+  }
+
+  static getIsRenewing(membershipStatus: MembershipStatus) {
+    return membershipStatus === MembershipStatus.RENEWING;
+  }
+
+  static getIsPending(membershipStatus: MembershipStatus) {
+    return membershipStatus === MembershipStatus.PENDING;
+  }
+
+  static getAge(birthday: string) {
+    return differenceInYears(new Date(), new Date(birthday));
+  }
+
+  static getIsUnderage(birthday: string) {
+    return this.getAge(birthday) < ageConstants.ADULT;
   }
 }
 

--- a/src/domain/membership/graphql/MembershipInformation.graphql
+++ b/src/domain/membership/graphql/MembershipInformation.graphql
@@ -9,6 +9,9 @@ query MembershipInformation {
         expiration
         renewable
         membershipNumber
+        membershipStatus
+        birthDate
+        approverEmail
     }
 
 }

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -6,8 +6,8 @@ import { Button } from 'hds-react';
 import { MembershipInformation as MembershipInformationTypes } from '../../../graphql/generatedTypes';
 import LinkButton from '../../../common/components/linkButton/LinkButton';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
-import getFullName from '../helpers/getFullName';
 import MembershipPageLayout from '../MembershipPageLayout';
+import Membership from '../MembershipUtility';
 import styles from './membershipInformation.module.css';
 
 interface Props {
@@ -21,27 +21,22 @@ function MembershipInformation({
 }: Props) {
   const { t } = useTranslation();
 
-  const validUntil = convertDateToLocale(
-    membershipInformationTypes?.myYouthProfile?.expiration
-  );
+  const youthProfile = membershipInformationTypes?.myYouthProfile;
+  const profile = membershipInformationTypes?.myYouthProfile?.profile;
 
-  if (!membershipInformationTypes?.myYouthProfile?.membershipNumber) {
+  if (!youthProfile || !profile) {
     return null;
   }
 
+  const validUntil = convertDateToLocale(youthProfile.expiration);
+  const adminUrl = Membership.getAdminUrl(profile.id);
+  const profileFullName = Membership.getFullName(profile);
+
   return (
     <MembershipPageLayout
-      profileFullName={getFullName(membershipInformationTypes)}
-      membershipNumber={
-        membershipInformationTypes.myYouthProfile.membershipNumber
-      }
-      qrCode={
-        <QRCode
-          size={175}
-          // eslint-disable-next-line max-len
-          value={`${process.env.REACT_APP_ADMIN_URL}youthProfiles/${membershipInformationTypes.myYouthProfile?.profile?.id}/show`}
-        />
-      }
+      profileFullName={profileFullName}
+      membershipNumber={youthProfile.membershipNumber}
+      qrCode={adminUrl ? <QRCode size={175} value={adminUrl} /> : undefined}
       membershipExpiryTitle={t('membershipInformation.validUntil', {
         date: validUntil,
       })}

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -8,7 +8,6 @@ import LinkButton from '../../../common/components/linkButton/LinkButton';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import MembershipPageLayout from '../MembershipPageLayout';
 import Membership from '../MembershipUtility';
-import styles from './membershipInformation.module.css';
 
 interface Props {
   onRenewMembership: () => void;
@@ -41,18 +40,12 @@ function MembershipInformation({
         date: validUntil,
       })}
       mainActionButton={
-        <Button
-          type="button"
-          onClick={onRenewMembership}
-          className={styles.button}
-          data-cy="renew"
-        >
+        <Button type="button" onClick={onRenewMembership} data-cy="renew">
           {t('membershipInformation.renew')}
         </Button>
       }
       secondaryActionButton={
         <LinkButton
-          className={styles.button}
           path="/membership-details"
           component="Link"
           buttonText={t('membershipInformation.showProfileInformation')}

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -191,9 +191,10 @@ function MainActionButton({
   const isRenewable = membershipRenewable;
   const isPending = Membership.getIsPending(membershipStatus);
   const isRenewing = Membership.getIsRenewing(membershipStatus);
+  const isExpired = Membership.getIsExpired(membershipStatus);
   const isUnderage = Membership.getIsUnderage(birthday);
 
-  if (isRenewable && isUnderage) {
+  if ((isRenewable && isUnderage) || (isExpired && isUnderage)) {
     return (
       <RenewButton
         onRenewMembership={onRenewMembership}
@@ -202,7 +203,7 @@ function MainActionButton({
     );
   }
 
-  if (isRenewable) {
+  if (isRenewable || isExpired) {
     return (
       <RenewButton
         onRenewMembership={onRenewMembership}

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -3,53 +3,312 @@ import { useTranslation } from 'react-i18next';
 import { QRCode } from 'react-qrcode-logo';
 import { Button } from 'hds-react';
 
-import { MembershipInformation as MembershipInformationTypes } from '../../../graphql/generatedTypes';
+import {
+  MembershipInformation_myYouthProfile,
+  MembershipInformation_myYouthProfile_profile,
+  MembershipStatus,
+} from '../../../graphql/generatedTypes';
 import LinkButton from '../../../common/components/linkButton/LinkButton';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import MembershipPageLayout from '../MembershipPageLayout';
 import Membership from '../MembershipUtility';
 
-type Props = {
-  onRenewMembership: () => void;
-  membershipInformationTypes: MembershipInformationTypes;
+type MembershipExpiryTitleProps = {
+  membershipExpirationDate: string;
+  memberShipStatus: MembershipStatus;
+  membershipRenewable: boolean;
 };
 
-function MembershipInformation({
-  onRenewMembership,
-  membershipInformationTypes,
-}: Props) {
+function MembershipExpiryTitle({
+  membershipExpirationDate,
+  memberShipStatus,
+  membershipRenewable,
+}: MembershipExpiryTitleProps) {
   const { t } = useTranslation();
 
-  const youthProfile = membershipInformationTypes?.myYouthProfile;
-  const profile = membershipInformationTypes?.myYouthProfile?.profile;
+  const isRenewable = membershipRenewable;
+  const isExpired = Membership.getIsExpired(memberShipStatus);
+  const isActive = Membership.getIsActive(memberShipStatus);
+  const isRenewing = Membership.getIsRenewing(memberShipStatus);
+  const isPending = Membership.getIsPending(memberShipStatus);
 
-  if (!youthProfile || !profile) {
+  if (isExpired) {
+    return <>{t('membershipInformation.status.title.membershipExpired')}</>;
+  }
+
+  if (isRenewable && isActive) {
+    return (
+      <>
+        {t('membershipInformation.status.title.renewable', {
+          date: membershipExpirationDate,
+        })}
+      </>
+    );
+  }
+
+  if (isRenewing) {
+    return (
+      <>
+        {t('membershipInformation.status.title.renewing', {
+          date: membershipExpirationDate,
+        })}
+      </>
+    );
+  }
+
+  if (isPending) {
+    return <>{t('membershipInformation.status.title.pending')}</>;
+  }
+
+  // Membership is active
+  return (
+    <>
+      {t('membershipInformation.validUntil', {
+        date: membershipExpirationDate,
+      })}
+    </>
+  );
+}
+
+type MembershipExpiryDescriptionProps = {
+  membershipRenewable: boolean;
+  memberShipStatus: MembershipStatus;
+  birthday: string;
+  approverEmail: string;
+};
+
+function MembershipExpiryDescription({
+  membershipRenewable,
+  memberShipStatus,
+  birthday,
+  approverEmail,
+}: MembershipExpiryDescriptionProps) {
+  const { t } = useTranslation();
+
+  const isRenewable = membershipRenewable;
+  const isExpired = Membership.getIsExpired(memberShipStatus);
+  const isActive = Membership.getIsActive(memberShipStatus);
+  const isRenewing = Membership.getIsRenewing(memberShipStatus);
+  const isPending = Membership.getIsPending(memberShipStatus);
+  const isUnderage = Membership.getIsUnderage(birthday);
+
+  if (isRenewable && isActive && isUnderage) {
+    return <>{t('membershipInformation.status.description.renewable')}</>;
+  }
+
+  if (isRenewing && isUnderage) {
+    return (
+      <>
+        {t('membershipInformation.status.description.renewing', {
+          email: approverEmail,
+        })}
+      </>
+    );
+  }
+
+  if (isPending && isUnderage) {
+    return (
+      <>
+        {t('membershipInformation.status.description.pending', {
+          email: approverEmail,
+        })}
+      </>
+    );
+  }
+
+  if (isExpired && isUnderage) {
+    return <>{t('membershipInformation.status.description.expired')}</>;
+  }
+
+  return <></>;
+}
+
+type AdminLinkQrCodeProps = {
+  membershipStatus: MembershipStatus;
+  profileId: string;
+};
+
+function AdminLinkQrCode({
+  membershipStatus,
+  profileId,
+}: AdminLinkQrCodeProps) {
+  const adminUrl = Membership.getAdminUrl(profileId);
+  const isVisible =
+    Membership.getIsActive(membershipStatus) ||
+    Membership.getIsRenewing(membershipStatus);
+
+  if (!isVisible || !adminUrl) {
     return null;
   }
 
-  const validUntil = convertDateToLocale(youthProfile.expiration);
-  const adminUrl = Membership.getAdminUrl(profile.id);
+  return <QRCode size={175} value={adminUrl} />;
+}
+
+type RenewButtonProps = {
+  onRenewMembership: () => void;
+  label: string;
+};
+
+function RenewButton({ onRenewMembership, label }: RenewButtonProps) {
+  return (
+    <Button type="button" onClick={onRenewMembership} data-cy="renew">
+      {label}
+    </Button>
+  );
+}
+
+type ResendButtonProps = {
+  onResendConfirmationEmail: () => void;
+};
+
+function ResendButton({ onResendConfirmationEmail }: ResendButtonProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Button onClick={onResendConfirmationEmail}>
+      {t('confirmSendingProfile.buttonText')}
+    </Button>
+  );
+}
+
+type MainActionButtonProps = {
+  membershipRenewable: boolean;
+  membershipStatus: MembershipStatus;
+  onRenewMembership: () => void;
+  onResendConfirmationEmail: () => void;
+  birthday: string;
+};
+
+function MainActionButton({
+  membershipRenewable,
+  membershipStatus,
+  onRenewMembership,
+  onResendConfirmationEmail,
+  birthday,
+}: MainActionButtonProps) {
+  const { t } = useTranslation();
+
+  const isRenewable = membershipRenewable;
+  const isPending = Membership.getIsPending(membershipStatus);
+  const isRenewing = Membership.getIsRenewing(membershipStatus);
+  const isUnderage = Membership.getIsUnderage(birthday);
+
+  if (isRenewable && isUnderage) {
+    return (
+      <RenewButton
+        onRenewMembership={onRenewMembership}
+        label={t('membershipInformation.renewUnderage')}
+      />
+    );
+  }
+
+  if (isRenewable) {
+    return (
+      <RenewButton
+        onRenewMembership={onRenewMembership}
+        label={t('membershipInformation.renew')}
+      />
+    );
+  }
+
+  if (isPending || isRenewing) {
+    return (
+      <ResendButton onResendConfirmationEmail={onResendConfirmationEmail} />
+    );
+  }
+
+  return null;
+}
+
+type SecondaryActionButtonProps = {
+  membershipRenewable: boolean;
+  membershipStatus: MembershipStatus;
+};
+
+function SecondaryActionButton({
+  membershipRenewable,
+  membershipStatus,
+}: SecondaryActionButtonProps) {
+  const { t } = useTranslation();
+
+  const isRenewable = membershipRenewable;
+  const isExpired = Membership.getIsExpired(membershipStatus);
+  const isActive = Membership.getIsActive(membershipStatus);
+  const isRenewing = Membership.getIsRenewing(membershipStatus);
+
+  if ((isRenewable && !isExpired) || isActive || isRenewing) {
+    return (
+      <LinkButton
+        path="/membership-details"
+        component="Link"
+        buttonText={t('membershipInformation.showProfileInformation')}
+        variant="secondary"
+      />
+    );
+  }
+
+  return null;
+}
+
+type Props = {
+  youthProfile: MembershipInformation_myYouthProfile;
+  profile: MembershipInformation_myYouthProfile_profile;
+  onRenewMembership: () => void;
+  onResendConfirmationEmail: () => void;
+};
+
+function MembershipInformation({
+  youthProfile,
+  profile,
+  onRenewMembership,
+  onResendConfirmationEmail,
+}: Props) {
+  const membershipStatus = youthProfile.membershipStatus;
+  const memberShipRenewable = youthProfile.renewable;
+  const birthday = youthProfile.birthDate;
+  const expirationLocaleDateString = convertDateToLocale(
+    youthProfile.expiration
+  );
   const profileFullName = Membership.getFullName(profile);
 
   return (
     <MembershipPageLayout
       profileFullName={profileFullName}
       membershipNumber={youthProfile.membershipNumber}
-      qrCode={adminUrl ? <QRCode size={175} value={adminUrl} /> : undefined}
-      membershipExpiryTitle={t('membershipInformation.validUntil', {
-        date: validUntil,
-      })}
+      qrCode={
+        <AdminLinkQrCode
+          membershipStatus={membershipStatus}
+          profileId={profile.id}
+        />
+      }
+      membershipExpiryTitle={
+        <MembershipExpiryTitle
+          membershipExpirationDate={expirationLocaleDateString}
+          memberShipStatus={membershipStatus}
+          membershipRenewable={memberShipRenewable}
+        />
+      }
+      membershipExpiryDescription={
+        <MembershipExpiryDescription
+          memberShipStatus={membershipStatus}
+          membershipRenewable={memberShipRenewable}
+          birthday={birthday}
+          approverEmail={youthProfile.approverEmail}
+        />
+      }
       mainActionButton={
-        <Button type="button" onClick={onRenewMembership} data-cy="renew">
-          {t('membershipInformation.renew')}
-        </Button>
+        <MainActionButton
+          membershipRenewable={memberShipRenewable}
+          membershipStatus={membershipStatus}
+          onRenewMembership={onRenewMembership}
+          onResendConfirmationEmail={onResendConfirmationEmail}
+          birthday={birthday}
+        />
       }
       secondaryActionButton={
-        <LinkButton
-          path="/membership-details"
-          component="Link"
-          buttonText={t('membershipInformation.showProfileInformation')}
-          variant="secondary"
+        <SecondaryActionButton
+          membershipRenewable={memberShipRenewable}
+          membershipStatus={membershipStatus}
         />
       }
     />

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -9,10 +9,10 @@ import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import MembershipPageLayout from '../MembershipPageLayout';
 import Membership from '../MembershipUtility';
 
-interface Props {
+type Props = {
   onRenewMembership: () => void;
   membershipInformationTypes: MembershipInformationTypes;
-}
+};
 
 function MembershipInformation({
   onRenewMembership,

--- a/src/domain/membership/information/MembershipInformation.tsx
+++ b/src/domain/membership/information/MembershipInformation.tsx
@@ -5,9 +5,9 @@ import { Button } from 'hds-react';
 
 import { MembershipInformation as MembershipInformationTypes } from '../../../graphql/generatedTypes';
 import LinkButton from '../../../common/components/linkButton/LinkButton';
-import Text from '../../../common/components/text/Text';
 import convertDateToLocale from '../../../common/helpers/convertDateToLocale';
 import getFullName from '../helpers/getFullName';
+import MembershipPageLayout from '../MembershipPageLayout';
 import styles from './membershipInformation.module.css';
 
 interface Props {
@@ -25,53 +25,46 @@ function MembershipInformation({
     membershipInformationTypes?.myYouthProfile?.expiration
   );
 
+  if (!membershipInformationTypes?.myYouthProfile?.membershipNumber) {
+    return null;
+  }
+
   return (
-    <div className={styles.container}>
-      {membershipInformationTypes && (
-        <React.Fragment>
-          <Text variant="h1">{getFullName(membershipInformationTypes)}</Text>
-          <Text variant="h2" className={styles.membershipNumber}>
-            {t('membershipInformation.title', {
-              number:
-                membershipInformationTypes?.myYouthProfile?.membershipNumber,
-            })}
-          </Text>
-          <p className={styles.validUntil}>
-            {t('membershipInformation.validUntil', { date: validUntil })}
-          </p>
-          <QRCode
-            size={175}
-            // eslint-disable-next-line max-len
-            value={`${process.env.REACT_APP_ADMIN_URL}youthProfiles/${membershipInformationTypes.myYouthProfile?.profile?.id}/show`}
-          />
-           
-          {membershipInformationTypes?.myYouthProfile?.renewable && (
-            <Button
-              type="button"
-              onClick={onRenewMembership}
-              className={styles.button}
-              data-cy="renew"
-            >
-              {t('membershipInformation.renew')}
-            </Button>
-          )}
-          <LinkButton
-            className={styles.button}
-            path="/membership-details"
-            component="Link"
-            buttonText={t('membershipInformation.showProfileInformation')}
-            variant="secondary"
-          />
-          <LinkButton
-            className={styles.button}
-            path={t('feedback.giveFeedback.link')}
-            component="a"
-            buttonText={t('feedback.giveFeedback.label')}
-            variant="secondary"
-          />
-        </React.Fragment>
-      )}
-    </div>
+    <MembershipPageLayout
+      profileFullName={getFullName(membershipInformationTypes)}
+      membershipNumber={
+        membershipInformationTypes.myYouthProfile.membershipNumber
+      }
+      qrCode={
+        <QRCode
+          size={175}
+          // eslint-disable-next-line max-len
+          value={`${process.env.REACT_APP_ADMIN_URL}youthProfiles/${membershipInformationTypes.myYouthProfile?.profile?.id}/show`}
+        />
+      }
+      membershipExpiryTitle={t('membershipInformation.validUntil', {
+        date: validUntil,
+      })}
+      mainActionButton={
+        <Button
+          type="button"
+          onClick={onRenewMembership}
+          className={styles.button}
+          data-cy="renew"
+        >
+          {t('membershipInformation.renew')}
+        </Button>
+      }
+      secondaryActionButton={
+        <LinkButton
+          className={styles.button}
+          path="/membership-details"
+          component="Link"
+          buttonText={t('membershipInformation.showProfileInformation')}
+          variant="secondary"
+        />
+      }
+    />
   );
 }
 

--- a/src/domain/membership/information/__tests__/MembershipInformation.test.jsx
+++ b/src/domain/membership/information/__tests__/MembershipInformation.test.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { subYears, format } from 'date-fns';
+
+import { render, screen } from '../../../../common/test/testing-library';
+import MembershipInformation from '../MembershipInformation';
+import { MembershipStatus } from '../../../../graphql/generatedTypes';
+
+function getMinorBirthday() {
+  // 15 years today
+  const birthday = subYears(new Date(), 15);
+
+  return format(birthday, 'yyyy-MM-dd');
+}
+
+function validateView({
+  title,
+  description,
+  mainButtonLabel,
+  secondaryButtonLabel,
+}) {
+  expect(screen.getByText(title)).toBeInTheDocument();
+
+  if (description) {
+    expect(screen.getByText(description)).toBeInTheDocument();
+  }
+
+  if (mainButtonLabel) {
+    expect(
+      screen.getByRole('button', { name: mainButtonLabel })
+    ).toBeInTheDocument();
+  }
+
+  if (secondaryButtonLabel) {
+    expect(
+      screen.getByRole('link', { name: secondaryButtonLabel })
+    ).toBeInTheDocument();
+  }
+}
+
+const renderComponent = props => {
+  const injectedProps = {
+    ...props,
+    youthProfile: {
+      ...props.youthProfile,
+      approverEmail: 'test@hel.fi',
+      expiration: '2020-10-10',
+    },
+  };
+
+  return render(<MembershipInformation {...injectedProps} />);
+};
+
+describe('<MembershipInformation />', () => {
+  describe('when minor', () => {
+    const renderMinor = (props = {}) => {
+      const injectedProps = {
+        ...props,
+        youthProfile: {
+          ...props.youthProfile,
+          birthDate: getMinorBirthday(),
+        },
+      };
+
+      return renderComponent(injectedProps);
+    };
+
+    it('ACTIVE, renewable', () => {
+      renderMinor({
+        youthProfile: {
+          membershipStatus: MembershipStatus.ACTIVE,
+          renewable: true,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: /Jäsenyysaika umpeutuu .*/,
+        description: 'Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.',
+        mainButtonLabel: 'Lähetä uusimispyyntö huoltajalle',
+        secondaryButtonLabel: 'Näytä profiilin tiedot',
+      });
+    });
+
+    it('RENEWING', () => {
+      renderMinor({
+        youthProfile: {
+          membershipStatus: MembershipStatus.RENEWING,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: /Jäsenyysaika umpeutuu .*. Uusiminen odottaa huoltajan hyväksyntää./,
+        description: /Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen .*/,
+        mainButtonLabel: 'Lähetä uusi pyyntö huoltajalle',
+        secondaryButtonLabel: 'Näytä profiilin tiedot',
+      });
+    });
+
+    it('EXPIRED', () => {
+      renderMinor({
+        youthProfile: {
+          membershipStatus: MembershipStatus.EXPIRED,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: 'Jäsenyysaika on umpeutunut.',
+        description: 'Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.',
+        mainButtonLabel: 'Lähetä uusimispyyntö huoltajalle',
+      });
+    });
+
+    it('PENDING', () => {
+      renderMinor({
+        youthProfile: {
+          membershipStatus: MembershipStatus.PENDING,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: 'Jäsenyyden uusiminen odottaa huoltajan hyväksyntää.',
+        description: /Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen .*/,
+        mainButtonLabel: 'Lähetä uusi pyyntö huoltajalle',
+      });
+    });
+  });
+
+  describe('when adult', () => {
+    const renderAdult = (props = {}) => renderComponent(props);
+
+    it('ACTIVE, renewable', () => {
+      renderAdult({
+        youthProfile: {
+          renewable: true,
+          membershipStatus: MembershipStatus.ACTIVE,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: /Jäsenyysaika umpeutuu .*/,
+        mainButtonLabel: 'Uusi jäsenyys',
+      });
+    });
+
+    it('EXPIRED', () => {
+      renderAdult({
+        youthProfile: {
+          membershipStatus: MembershipStatus.EXPIRED,
+        },
+        profile: {},
+      });
+
+      validateView({
+        title: 'Jäsenyysaika on umpeutunut.',
+        mainButtonLabel: 'Uusi jäsenyys',
+      });
+    });
+  });
+});

--- a/src/domain/membership/information/membershipInformation.module.css
+++ b/src/domain/membership/information/membershipInformation.module.css
@@ -1,20 +1,5 @@
-.container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-.membershipNumber {
-    font-size: var(--fontsize-heading-m);
-}
-
-.validUntil {
-    margin-bottom: var(--spacing-m);
-}
-
 .button {
-    margin-top: var(--spacing-s);
-    min-width: 230px;
-    margin-bottom: 15px;
+  margin-top: var(--spacing-s);
+  min-width: 230px;
+  margin-bottom: 15px;
 }
-

--- a/src/domain/membership/information/membershipInformation.module.css
+++ b/src/domain/membership/information/membershipInformation.module.css
@@ -1,5 +1,0 @@
-.button {
-  margin-top: var(--spacing-s);
-  min-width: 230px;
-  margin-bottom: 15px;
-}

--- a/src/domain/membership/membershipPageLayout.module.css
+++ b/src/domain/membership/membershipPageLayout.module.css
@@ -8,11 +8,10 @@
   font-size: var(--fontsize-heading-m);
 }
 
-.membershipExpiryTitle {
+.membershipStatus {
   margin-bottom: var(--spacing-m);
-
-  font-weight: 600;
 }
 
-.membershipExpiryDescription {
+.membershipExpiryTitle {
+  font-weight: 600;
 }

--- a/src/domain/membership/membershipPageLayout.module.css
+++ b/src/domain/membership/membershipPageLayout.module.css
@@ -1,0 +1,22 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.membershipNumber {
+  font-size: var(--fontsize-heading-m);
+}
+
+.membershipExpiryTitle {
+  margin-bottom: var(--spacing-m);
+}
+
+.membershipExpiryDescription {
+}
+
+.button {
+  margin-top: var(--spacing-s);
+  min-width: 230px;
+  margin-bottom: 15px;
+}

--- a/src/domain/membership/membershipPageLayout.module.css
+++ b/src/domain/membership/membershipPageLayout.module.css
@@ -10,13 +10,9 @@
 
 .membershipExpiryTitle {
   margin-bottom: var(--spacing-m);
+
+  font-weight: 600;
 }
 
 .membershipExpiryDescription {
-}
-
-.button {
-  margin-top: var(--spacing-s);
-  min-width: 230px;
-  margin-bottom: 15px;
 }

--- a/src/domain/membership/useMembershipStatus.ts
+++ b/src/domain/membership/useMembershipStatus.ts
@@ -1,10 +1,7 @@
 import { useQuery, QueryHookOptions, ApolloError } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
-import {
-  MembershipStatus,
-  HasYouthProfile,
-} from '../../graphql/generatedTypes';
+import { HasYouthProfile } from '../../graphql/generatedTypes';
 
 const HAS_YOUTH_PROFILE = loader(
   '../youthProfile/graphql/HasYouthProfile.graphql'
@@ -12,7 +9,7 @@ const HAS_YOUTH_PROFILE = loader(
 
 type Props = QueryHookOptions<HasYouthProfile, Record<string, unknown>>;
 
-function useIsMembershipPending({ onError }: Props) {
+function useMembershipStatus({ onError }: Props) {
   const { data, loading } = useQuery<HasYouthProfile>(HAS_YOUTH_PROFILE, {
     onError: (error: ApolloError) => {
       if (onError) {
@@ -22,9 +19,8 @@ function useIsMembershipPending({ onError }: Props) {
   });
 
   const membershipStatus = data?.myYouthProfile?.membershipStatus;
-  const isMembershipPending = membershipStatus === MembershipStatus.PENDING;
 
-  return [isMembershipPending, loading];
+  return [membershipStatus, loading];
 }
 
-export default useIsMembershipPending;
+export default useMembershipStatus;

--- a/src/domain/membership/useMembershipStatus.ts
+++ b/src/domain/membership/useMembershipStatus.ts
@@ -1,7 +1,10 @@
 import { useQuery, QueryHookOptions, ApolloError } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
-import { HasYouthProfile } from '../../graphql/generatedTypes';
+import {
+  HasYouthProfile,
+  MembershipStatus,
+} from '../../graphql/generatedTypes';
 
 const HAS_YOUTH_PROFILE = loader(
   '../youthProfile/graphql/HasYouthProfile.graphql'
@@ -9,7 +12,9 @@ const HAS_YOUTH_PROFILE = loader(
 
 type Props = QueryHookOptions<HasYouthProfile, Record<string, unknown>>;
 
-function useMembershipStatus({ onError }: Props) {
+function useMembershipStatus({
+  onError,
+}: Props): [MembershipStatus | undefined, boolean] {
   const { data, loading } = useQuery<HasYouthProfile>(HAS_YOUTH_PROFILE, {
     onError: (error: ApolloError) => {
       if (onError) {

--- a/src/domain/youthProfile/create/CreateYouthProfilePage.tsx
+++ b/src/domain/youthProfile/create/CreateYouthProfilePage.tsx
@@ -5,11 +5,14 @@ import { useQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 import { User } from 'oidc-client';
 
-import { PrefillRegistartion } from '../../../graphql/generatedTypes';
+import {
+  MembershipStatus,
+  PrefillRegistartion,
+} from '../../../graphql/generatedTypes';
 import PageContent from '../../../common/components/layout/PageContent';
 import toastNotification from '../../../common/helpers/toastNotification/toastNotification';
 import getAuthenticatedUser from '../../auth/getAuthenticatedUser';
-import useIsMembershipPending from '../../membership/useIsMembershipPending';
+import useMembershipStatus from '../../membership/useMembershipStatus';
 import CreateYouthProfile from './CreateYouthProfile';
 
 const PREFILL_REGISTRATION = loader('../graphql/PrefillRegistration.graphql');
@@ -27,10 +30,7 @@ function CreateYouthProfilePage() {
       },
     }
   );
-  const [
-    isMembershipPending,
-    loadingIsMembershipPending,
-  ] = useIsMembershipPending({
+  const [membershipStatus, loadingIsMembershipPending] = useMembershipStatus({
     onError: () => {
       history.push('/login');
     },
@@ -45,7 +45,7 @@ function CreateYouthProfilePage() {
       .catch(() => history.push('/login'));
   }, [history]);
 
-  if (isMembershipPending) {
+  if (membershipStatus === MembershipStatus.PENDING) {
     return <Redirect to="/" />;
   }
 

--- a/src/domain/youthProfile/sent/__tests_/__snapshots__/SentYouthProfile.test.tsx.snap
+++ b/src/domain/youthProfile/sent/__tests_/__snapshots__/SentYouthProfile.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`match snapshot 1`] = `
       <span
         class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
       >
-        Lähetä uusi pyyntö huoltajallle
+        Lähetä uusi pyyntö huoltajalle
       </span>
     </button>
     <br />

--- a/src/domain/youthProfile/sent/__tests_/__snapshots__/SentYouthProfile.test.tsx.snap
+++ b/src/domain/youthProfile/sent/__tests_/__snapshots__/SentYouthProfile.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`match snapshot 1`] = `
       <span
         class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
       >
-        Lähetä uusi varmistusviesti
+        Lähetä uusi pyyntö huoltajallle
       </span>
     </button>
     <br />

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -123,6 +123,9 @@ export interface MembershipInformation_myYouthProfile {
   readonly expiration: any;
   readonly renewable: boolean;
   readonly membershipNumber: string;
+  readonly membershipStatus: MembershipStatus;
+  readonly birthDate: any;
+  readonly approverEmail: string;
 }
 
 export interface MembershipInformation {
@@ -303,7 +306,7 @@ export interface HasYouthProfile {
 // ====================================================
 
 export interface NameQuery_myProfile {
-  readonly __typename: "ProfileNode";
+  readonly __typename: "ProfileWithVerifiedPersonalInformationNode";
   readonly firstName: string;
   readonly lastName: string;
   readonly nickname: string;
@@ -365,7 +368,7 @@ export interface PrefillRegistartion_myProfile_primaryEmail {
 }
 
 export interface PrefillRegistartion_myProfile {
-  readonly __typename: "ProfileNode";
+  readonly __typename: "ProfileWithVerifiedPersonalInformationNode";
   readonly firstName: string;
   readonly lastName: string;
   readonly language: Language | null;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -102,7 +102,7 @@
   "membershipInformation": {
     "pageTitle": "Membership information",
     "renew": "Renew membership",
-    "renewUnderage": "",
+    "renewUnderage": "Send a renewal request to the guardian",
     "renewSuccessMessage": "Membership renewed successfully!",
     "renewSuccessTitle": "Success",
     "showProfileInformation": "Show profile information",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -45,7 +45,7 @@
     "errorMessage": "An error occured while logging in. Please try again"
   },
   "confirmSendingProfile": {
-    "buttonText": "Resend the membership request",
+    "buttonText": "Send a new request to the guardian",
     "helpText": "Your membership application has been sent to",
     "linkToShowSentData": "Display your application",
     "sendAgainHelpText": "Approval email has been re-sent to",
@@ -102,11 +102,26 @@
   "membershipInformation": {
     "pageTitle": "Membership information",
     "renew": "Renew membership",
+    "renewUnderage": "",
     "renewSuccessMessage": "Membership renewed successfully!",
     "renewSuccessTitle": "Success",
     "showProfileInformation": "Show profile information",
     "title": "Membership card number {{number}}",
-    "validUntil": "Valid until {{date}}"
+    "validUntil": "Valid until {{date}}",
+    "status": {
+      "title": {
+        "membershipExpired": "Membership has expired.",
+        "renewable": "Membership expires on {{date}}.",
+        "pending": "Renewal of membership is awaiting for guardian approval.",
+        "renewing": "Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      },
+      "description": {
+        "renewable": "Resubmit your membership to your guardian for approval.",
+        "pending": "Your renewal request has been sent to {{email}}",
+        "renewing": "Your renewal request has been sent to {{email}}",
+        "expired": "Resubmit your membership to your guardian for approval."
+      }
+    }
   },
   "meta": {
     "description": "Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -45,7 +45,7 @@
     "errorMessage": "Tapahtui virhe. Yritä uudestaan"
   },
   "confirmSendingProfile": {
-    "buttonText": "Lähetä uusi pyyntö huoltajallle",
+    "buttonText": "Lähetä uusi pyyntö huoltajalle",
     "helpText": "Olet lähettänyt jäsenyyden hyväksyttäväksi osoitteeseen",
     "linkToShowSentData": "Näytä hakemuksen tiedot",
     "sendAgainHelpText": "Varmistusviesti on lähetetty uudestaan osoitteeseen",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -45,7 +45,7 @@
     "errorMessage": "Tapahtui virhe. Yritä uudestaan"
   },
   "confirmSendingProfile": {
-    "buttonText": "Lähetä uusi varmistusviesti",
+    "buttonText": "Lähetä uusi pyyntö huoltajallle",
     "helpText": "Olet lähettänyt jäsenyyden hyväksyttäväksi osoitteeseen",
     "linkToShowSentData": "Näytä hakemuksen tiedot",
     "sendAgainHelpText": "Varmistusviesti on lähetetty uudestaan osoitteeseen",
@@ -102,11 +102,26 @@
   "membershipInformation": {
     "pageTitle": "Jäsenyyden tiedot",
     "renew": "Uusi jäsenyys",
+    "renewUnderage": "Lähetä uusimispyyntö huoltajalle",
     "renewSuccessMessage": "Jäsenyys uusittu onnistuneesti!",
     "renewSuccessTitle": "Onnistui",
     "showProfileInformation": "Näytä profiilin tiedot",
     "title": "Jäsenkortin numero {{number}}",
-    "validUntil": "Voimassa {{date}} asti"
+    "validUntil": "Voimassa {{date}} asti.",
+    "status": {
+      "title": {
+        "membershipExpired": "Jäsenyysaika on umpeutunut.",
+        "renewable": "Jäsenyysaika umpeutuu {{date}}.",
+        "pending": "Jäsenyyden uusiminen odottaa huoltajan hyväksyntää.",
+        "renewing": "Jäsenyysaika umpeutuu {{date}}. Uusiminen odottaa huoltajan hyväksyntää."
+      },
+      "description": {
+        "renewable": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.",
+        "pending": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}",
+        "renewing": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}",
+        "expired": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi."
+      }
+    }
   },
   "meta": {
     "description": "Jässärillä pääset mukaan nuorisopalveluiden toimintaan. Jäsenyys takaa sinulle kivaa tekemistä, voit hengailla nuorisotaloilla, osallistua harrastusryhmiin, kursseille ja leireille, hakea projektiavustusta tai vaikka tuottaa oman tapahtuman! Nuorisotaloilla toimintaa ohjaavat koulutetut nuoriso-ohjaajat."

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -45,7 +45,7 @@
     "errorMessage": "Ett fel uppstod. Försök igen"
   },
   "confirmSendingProfile": {
-    "buttonText": "Skicka ett nytt verifieringsmeddelande",
+    "buttonText": "Skicka en ny begäran till vårdnadshavaren",
     "helpText": "Din medlemsansökan har skickats till",
     "linkToShowSentData": "Visa din ansökan",
     "sendAgainHelpText": "Verifieringsmeddelandet har skickats på nytt till",
@@ -102,11 +102,26 @@
   "membershipInformation": {
     "pageTitle": "Medlemskapsinformation",
     "renew": "Förnya medlemskapet",
+    "renewUnderage": "",
     "renewSuccessMessage": "Medlemskapet förnyades framgångsrikt!",
     "renewSuccessTitle": "Framgång",
     "showProfileInformation": "Visa profiluppifter",
     "title": "Medlemskortnummer {{number}}",
-    "validUntil": "Gäller till {{date}}"
+    "validUntil": "Gäller till {{date}}",
+    "status": {
+      "title": {
+        "membershipExpired": "Medlemskapet har löpt ut.",
+        "renewable": "Medlemskapet upphör att gälla den {{date}}.",
+        "pending": "Förnyelse av medlemskap väntar på vårdnadshavares godkännande.",
+        "renewing": "Medlemskapet upphör att gälla den {{date}}. Förnyelse väntar på vårdnadshavares godkännande."
+      },
+      "description": {
+        "renewable": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande.",
+        "pending": "Din förnyelsebegäran har skickats till {{email}}",
+        "renewing": "Din förnyelsebegäran har skickats till {{email}}",
+        "expired": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande."
+      }
+    }
   },
   "meta": {
     "description": "Jässäri är ditt medlemskort till ungdomsgårdarna. Medlemskapet garanterar trevliga aktiviteter: häng på ungdomsgårdarna, delta i hobbygrupper, ansök om projektunderstöd eller producera ett eget evenemang! Verksamheten leds av utbildade ungdomsledare."

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -102,7 +102,7 @@
   "membershipInformation": {
     "pageTitle": "Medlemskapsinformation",
     "renew": "Förnya medlemskapet",
-    "renewUnderage": "",
+    "renewUnderage": "Skicka en förnyelsebegäran till vårdnadshavaren",
     "renewSuccessMessage": "Medlemskapet förnyades framgångsrikt!",
     "renewSuccessTitle": "Framgång",
     "showProfileInformation": "Visa profiluppifter",


### PR DESCRIPTION
## Description

Previously the membership status of RENEWING was not reflected in the UI. It was also unclear which of the other states (ACTIVE, PENDING, EXPIRED) were handled to what degree.

As added complexity, we also want to show a slightly different UI for user's who are "adults" as opposed to when they are minors and need to have their membership approved.

As context, here are the different possible states:

**Membership status**  
PENDING -- Membership is not active and is awaiting approval from an approver  
ACTIVE -- Membership is active  
RENEWING -- Membership is active and is awaiting approval from an approver  
EXPIRED -- Membership has expired  

**On top of the status there other fields are used**  
`renewable` -- True when the membership can be renewed. True after `1.5` and until the membership is renewed.  
`birthDate` -- User's birthday, used to determine whether the user is a minor.  
`approvedTime` -- The time the user's membership has been approved. Missing for users who have just registered.

The relevant design files can be found from here: https://app.abstract.com/projects/b80d4d50-787f-11e9-ae1d-ef140a99b44b/branches/master/collections/e26374e2-c8b6-43a0-b017-3b6bf8d9e7b9

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-469](https://helsinkisolutionoffice.atlassian.net/browse/YM-469)

## How Has This Been Tested?

I've added unit tests to the membership view that validate against the design's expectations.

## Manual Testing Instructions for Reviewers

This is quite difficult to test as all of the states can't be reproduced by editing data from the admin. I tested the states locally by hardcoding values. The behaviour should be in line with the design. Moreover, the current view the user is redirected to after registration should be unchanged.
