### PR TITLE
YM-478 | Remove user survey feedback link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Approval process always allowing photo usage regardless of choice
 - [Accessibility] Announce title changes with aria-live
 
+### Removed
+
+- Feedback link into user survey
+
 ## [1.3.1] - 2021-02-18
 
 ### Fixed

--- a/src/domain/membership/MembershipPageLayout.tsx
+++ b/src/domain/membership/MembershipPageLayout.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import LinkButton from '../../common/components/linkButton/LinkButton';
 import Text from '../../common/components/text/Text';
 import Stack from '../../common/components/stack/Stack';
 import styles from './membershipPageLayout.module.css';
@@ -47,12 +46,6 @@ function MembershipPageLayout({
       <Stack space="m">
         {mainActionButton && mainActionButton}
         {secondaryActionButton && secondaryActionButton}
-        <LinkButton
-          path={t('feedback.giveFeedback.link')}
-          component="a"
-          buttonText={t('feedback.giveFeedback.label')}
-          variant="secondary"
-        />
       </Stack>
     </div>
   );

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -254,12 +254,6 @@
     "heading": "{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire",
     "content": "Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>"
   },
-  "feedback": {
-    "giveFeedback": {
-      "label": "Give feedback of the Jässäri service",
-      "link": "https://docs.google.com/forms/d/e/1FAIpQLSfpPCeAdiT9pcMRazxqA9DW-mbqoN2kNwaV53XydjzHWdyFKw/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
-    }
-  },
   "fields": {
     "firstName": "a first name",
     "lastName": "a last name",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -254,12 +254,6 @@
     "heading": "{{ youth_profile.profile.first_name }} nuorisopalveluiden jäsenyytesi on vanhentumassa",
     "content": "Tevehdys {{ youth_profile.profile.first_name }}! Nuorisopalveluiden jäsenyytesi on vanhentumassa. Uusi jäsenyytesi helposti täällä https://jassari.hel.fi/  Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/ <br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/<br /><br /> <i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
   },
-  "feedback": {
-    "giveFeedback": {
-      "label": "Anna palautetta Jässäri verkkopalvelusta",
-      "link": "https://docs.google.com/forms/d/e/1FAIpQLSdqw2Lq3qooEeRdgr0sV0-Wv-4XcV7IZVzq1HuWoLRa2M7tEg/viewform?usp=pp_url&entry.1982410290=Nuorten+j%C3%A4senkortti"
-    }
-  },
   "fields": {
     "firstName": "etunimi",
     "lastName": "sukunimi",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -254,12 +254,6 @@
     "heading": "{{ youth_profile.profile.first_name }} ditt medlemskap i ungdomstjänsterna håller på att gå ut",
     "content": "Hejsan {{ youth_profile.profile.first_name }}! Ditt medlemskap i ungdomstjänsterna håller på att gå ut. Det är enkelt att förnya medlemskapet här https://jassari.hel.fi/ <br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>"
   },
-  "feedback": {
-    "giveFeedback": {
-      "label": "Ge respons om Jässäri tjänsten",
-      "link": "https://docs.google.com/forms/d/e/1FAIpQLSf0mf1gIUZ-k768RkOdBQm3bjp6TCDWQa1Wc1r_3WiYbDXLAA/viewform?usp=pp_url&entry.1982410290=J%C3%A4ss%C3%A4ri"
-    }
-  },
   "fields": {
     "firstName": "ett förnamn",
     "lastName": "ett efternamn",


### PR DESCRIPTION
## Description

User survey is over so we can remove the link to it.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-478](https://helsinkisolutionoffice.atlassian.net/browse/YM-478)

## How Has This Been Tested?

I've manually verified that the link is missing.
