### PR TITLE
YM-487 | Option to define additional locales with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ REACT_APP_PROFILE_LINK=https://profiili.test.kuva.hel.ninja/loginsso
 REACT_APP_ADMIN_URL=https://jassari-admin.test.kuva.hel.ninja/
 REACT_APP_SENTRY_DSN=https://6a047934d0d0456f8dd6a8f39ac969bb@sentry.hel.ninja/59
 REACT_APP_VERSION=$npm_package_version
+REACT_APP_ADDITIONAL_LOCALES=fr,ru,et,so,ar

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,5 +60,6 @@ jobs:
       run: yarn ci
       env:
         REACT_APP_PROFILE_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
+        REACT_APP_ADDITIONAL_LOCALES: "fr,ru,et,so,ar"
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -38,6 +38,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.${{ env.BASE_DOMAIN }}/"
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: "https://6a047934d0d0456f8dd6a8f39ac969bb@sentry.hel.ninja/59"
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
+          DOCKER_BUILD_ARG_REACT_APP_ADDITIONAL_LOCALES: "fr,ru,et,so,ar"
 
   review:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,6 +41,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_ADMIN_URL: "https://jassari-admin.${{ env.BASE_DOMAIN }}/"
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: "https://6a047934d0d0456f8dd6a8f39ac969bb@sentry.hel.ninja/59"
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE: "https://api.hel.fi/auth/helsinkiprofile"
+          DOCKER_BUILD_ARG_REACT_APP_ADDITIONAL_LOCALES: "fr,ru,et,so,ar"
 
   staging:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Logic to handle the renewing membership status
+- Option to define additional locales with environment variables
 
 ### Fixed
 

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -1,0 +1,39 @@
+import Config from '../config';
+
+describe('Config service', () => {
+  let env = {};
+
+  beforeEach(() => {
+    env = process.env;
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  describe('additionalLanguages', () => {
+    it('should return an empty array when REACT_APP_ADDITIONAL_LOCALES is not defined', () => {
+      delete process.env.REACT_APP_ADDITIONAL_LOCALES;
+
+      expect(Config.additionalLocales).toEqual([]);
+
+      process.env.REACT_APP_ADDITIONAL_LOCALES = '';
+
+      expect(Config.additionalLocales).toEqual([]);
+
+      process.env.REACT_APP_ADDITIONAL_LOCALES = undefined;
+
+      expect(Config.additionalLocales).toEqual([]);
+    });
+
+    it('should return additional languages as a string array', () => {
+      process.env.REACT_APP_ADDITIONAL_LOCALES = 'fr,ru,et,so,ar';
+
+      expect(Config.additionalLocales).toEqual(['fr', 'ru', 'et', 'so', 'ar']);
+
+      process.env.REACT_APP_ADDITIONAL_LOCALES = 'fr, ru, et, so, ar';
+
+      expect(Config.additionalLocales).toEqual(['fr', 'ru', 'et', 'so', 'ar']);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,21 @@ class Config {
   static get adminUrl() {
     return process.env.REACT_APP_ADMIN_URL;
   }
+
+  static get additionalLocales(): string[] {
+    const additionalLocalesString = process.env.REACT_APP_ADDITIONAL_LOCALES;
+
+    if (!additionalLocalesString || additionalLocalesString === 'undefined') {
+      return [];
+    }
+
+    // Remove whitespace and split into an array
+    return additionalLocalesString.replace(/\s/g, '').split(',');
+  }
+
+  static get isTestRun() {
+    return process.env.NODE_ENV === 'test';
+  }
 }
 
 export default Config;

--- a/src/i18n/__tests__/I18nService.test.js
+++ b/src/i18n/__tests__/I18nService.test.js
@@ -20,7 +20,16 @@ describe('I18nService', () => {
   });
 
   it('static languages getter should return supported languages', () => {
-    expect(I18nService.languages).toEqual(['fi', 'sv', 'en']);
+    expect(I18nService.languages).toEqual([
+      'fi',
+      'sv',
+      'en',
+      'fr',
+      'ru',
+      'et',
+      'so',
+      'ar',
+    ]);
   });
 
   it('static get should return the i18next instance', () => {
@@ -79,6 +88,11 @@ describe('I18nService', () => {
         fi: expect.any(Object),
         sv: expect.any(Object),
         en: expect.any(Object),
+        fr: expect.any(Object),
+        ru: expect.any(Object),
+        et: expect.any(Object),
+        so: expect.any(Object),
+        ar: expect.any(Object),
       });
       expect(initParams.fallbackLng).toEqual(['fi']);
       expect(initParams.whitelist).toEqual([

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,18 @@
+class Logger {
+  log(...args: Parameters<typeof console['log']>) {
+    // eslint-disable-next-line no-console
+    return console.log(...args);
+  }
+
+  error(...args: Parameters<typeof console['error']>) {
+    // eslint-disable-next-line no-console
+    return console.error(...args);
+  }
+
+  info(...args: Parameters<typeof console['info']>) {
+    // eslint-disable-next-line no-console
+    return console.info(...args);
+  }
+}
+
+export default new Logger();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Allows additional locales to be defined with `REACT_APP_ADDITIONAL_LOCALES` environment variable.

The format for the config is a string of comma separated ISO 639-1 values.

Locales found from the config are used to search for translation files, which are then configured for i18next.

Additional languages have been configured for use in review and staging environments. Users should expect to see error for missing locales.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-487](https://helsinkisolutionoffice.atlassian.net/browse/YM-487)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->

I've added or modified unit level tests.
