### PR TITLE
YM-484 | Add support for language direction detection based on locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Logic to handle the renewing membership status
 - Option to define additional locales with environment variables
+- Support for language direction detection based on locale
 
 ### Fixed
 

--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -61,6 +61,15 @@ class I18nService {
   static init(history: H.History) {
     const resources = getResources(this.languages);
 
+    // Set languageChanged for direction event before initialization so
+    // that direction is set on first load
+    i18n.on('languageChanged', (nextLanguage: Language) => {
+      // Sync selected languages direction into HTML document
+      if (document) {
+        document.dir = this.get().dir(nextLanguage);
+      }
+    });
+
     i18n
       .use(LanguageDetector)
       .use(initReactI18next)
@@ -85,6 +94,7 @@ class I18nService {
     setYupLocale();
 
     i18n.on('languageChanged', (nextLanguage: Language) => {
+      // If necessary, change language in pathname
       const pathname = window.location.pathname;
       const containsLanguage = this.languages.reduce(
         (contains, language) => contains || pathname.includes(`/${language}/`),

--- a/src/i18n/__tests__/I18nService.test.js
+++ b/src/i18n/__tests__/I18nService.test.js
@@ -53,23 +53,26 @@ describe('I18nService', () => {
       delete window.location;
       window.location = new URL('http://localhost/fi/');
 
-      const i18nOn = jest.spyOn(i18n, 'on');
-
       I18nService.init(fakeHistory);
-
-      expect(i18nOn).toHaveBeenCalledWith(
-        'languageChanged',
-        expect.any(Function)
-      );
-
-      const languageChangeCallbackFunction = i18nOn.mock.calls[0][1];
-
-      languageChangeCallbackFunction('sv');
+      I18nService.get().changeLanguage('sv');
 
       expect(replace).toHaveBeenCalledWith('/sv/');
 
       delete window.location;
       window.location = originalWindow;
+    });
+
+    // eslint-disable-next-line max-len
+    it('should extend the language change functionality by changing the language direction within the html document', () => {
+      const dirSpy = jest.spyOn(document, 'dir', 'set');
+
+      I18nService.init(fakeHistory);
+
+      expect(dirSpy).toHaveBeenCalledWith('ltr');
+
+      I18nService.get().changeLanguage('ar');
+
+      expect(dirSpy).toHaveBeenCalledWith('rtl');
     });
 
     it('should configure i18next', () => {


### PR DESCRIPTION
## Description

After this change, language direction is detected on language change and it is synced into the document by toggling the dir attribute in the HTML element.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-484](https://helsinkisolutionoffice.atlassian.net/browse/YM-484)

## How Has This Been Tested?

I've added unit level tests to check that the behaviour.
