### PR TITLE
YM-489 | Use i18n service to find options for language menu

### DIFF
--- a/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -133,6 +133,61 @@ exports[`matches snapshot 1`] = `
                       English
                     </span>
                   </a>
+                  <a
+                    class="Menu-module_item__3yQdE "
+                    href="#"
+                    lang="fr"
+                  >
+                    <span
+                      class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                    >
+                      language.fr
+                    </span>
+                  </a>
+                  <a
+                    class="Menu-module_item__3yQdE "
+                    href="#"
+                    lang="ru"
+                  >
+                    <span
+                      class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                    >
+                      language.ru
+                    </span>
+                  </a>
+                  <a
+                    class="Menu-module_item__3yQdE "
+                    href="#"
+                    lang="et"
+                  >
+                    <span
+                      class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                    >
+                      language.et
+                    </span>
+                  </a>
+                  <a
+                    class="Menu-module_item__3yQdE "
+                    href="#"
+                    lang="so"
+                  >
+                    <span
+                      class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                    >
+                      language.so
+                    </span>
+                  </a>
+                  <a
+                    class="Menu-module_item__3yQdE "
+                    href="#"
+                    lang="ar"
+                  >
+                    <span
+                      class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                    >
+                      language.ar
+                    </span>
+                  </a>
                 </div>
               </div>
               <div

--- a/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`matches snapshot 1`] = `
                 >
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="fi"
                   >
@@ -113,6 +114,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="sv"
                   >
@@ -124,6 +126,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="en"
                   >
@@ -135,6 +138,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="fr"
                   >
@@ -146,6 +150,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="ru"
                   >
@@ -157,6 +162,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="et"
                   >
@@ -168,6 +174,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="ltr"
                     href="#"
                     lang="so"
                   >
@@ -179,6 +186,7 @@ exports[`matches snapshot 1`] = `
                   </a>
                   <a
                     class="Menu-module_item__3yQdE "
+                    dir="rtl"
                     href="#"
                     lang="ar"
                   >

--- a/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/common/components/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                     >
-                      language.fr
+                      français
                     </span>
                   </a>
                   <a
@@ -152,7 +152,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                     >
-                      language.ru
+                      Русский язык
                     </span>
                   </a>
                   <a
@@ -163,7 +163,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                     >
-                      language.et
+                      eesti keel
                     </span>
                   </a>
                   <a
@@ -174,7 +174,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                     >
-                      language.so
+                      af Soomaali
                     </span>
                   </a>
                   <a
@@ -185,7 +185,7 @@ exports[`matches snapshot 1`] = `
                     <span
                       class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                     >
-                      language.ar
+                      العربية
                     </span>
                   </a>
                 </div>

--- a/src/common/components/layout/header/Header.tsx
+++ b/src/common/components/layout/header/Header.tsx
@@ -91,6 +91,7 @@ function Header({ variant = 'default' }: Props) {
                 }
                 label={t(`language.${normalizedLanguageCode}`)}
                 lang={normalizedLanguageCode}
+                dir={I18nService.dir(normalizedLanguageCode)}
               />
             ))}
           </Navigation.LanguageSelector>

--- a/src/common/components/layout/header/Header.tsx
+++ b/src/common/components/layout/header/Header.tsx
@@ -6,6 +6,7 @@ import { loader } from 'graphql.macro';
 import { useQuery } from '@apollo/client';
 import { useMatomo } from '@datapunt/matomo-tracker-react';
 
+import I18nService from '../../../../i18n/I18nService';
 import toastNotification from '../../../helpers/toastNotification/toastNotification';
 import { NameQuery } from '../../../../graphql/generatedTypes';
 import authenticate from '../../../../domain/auth/authenticate';
@@ -18,8 +19,6 @@ import styles from './Header.module.css';
 const NAME_QUERY = loader(
   '../../../../domain/youthProfile/graphql/NameQuery.graphql'
 );
-
-const languages = ['fi', 'sv', 'en'];
 
 // Approver variant is shown for approver view. The approver should not
 // be shown the user menu, nor should the header contain links for
@@ -83,7 +82,7 @@ function Header({ variant = 'default' }: Props) {
             label={normalizedLanguageCode.toUpperCase()}
             buttonAriaLabel={t(`language.${normalizedLanguageCode}`)}
           >
-            {languages.map(normalizedLanguageCode => (
+            {I18nService.languages.map(normalizedLanguageCode => (
               <Navigation.Item
                 key={normalizedLanguageCode}
                 href="#"

--- a/src/common/components/layout/header/Header.tsx
+++ b/src/common/components/layout/header/Header.tsx
@@ -19,11 +19,7 @@ const NAME_QUERY = loader(
   '../../../../domain/youthProfile/graphql/NameQuery.graphql'
 );
 
-const languages = {
-  fi: 'Suomi',
-  sv: 'Svenska',
-  en: 'English',
-};
+const languages = ['fi', 'sv', 'en'];
 
 // Approver variant is shown for approver view. The approver should not
 // be shown the user menu, nor should the header contain links for
@@ -64,9 +60,7 @@ function Header({ variant = 'default' }: Props) {
 
   const isDefaultVariant = variant === 'default';
   const isApproverVariant = variant === 'approver';
-  const normalizedLanguageCode = getLanguageCode(
-    i18n.languages[0]
-  ) as keyof typeof languages;
+  const normalizedLanguageCode = getLanguageCode(i18n.languages[0]);
   const logoLanguage = normalizedLanguageCode === 'sv' ? 'sv' : 'fi';
   const userName = data?.myProfile?.firstName;
   const isCreatingProfile = isAuthenticated && !userName;
@@ -87,21 +81,19 @@ function Header({ variant = 'default' }: Props) {
         <Navigation.Actions>
           <Navigation.LanguageSelector
             label={normalizedLanguageCode.toUpperCase()}
-            buttonAriaLabel={languages[normalizedLanguageCode]}
+            buttonAriaLabel={t(`language.${normalizedLanguageCode}`)}
           >
-            {Object.entries(languages).map(
-              ([normalizedLanguageCode, label]) => (
-                <Navigation.Item
-                  key={normalizedLanguageCode}
-                  href="#"
-                  onClick={(e: React.SyntheticEvent<HTMLAnchorElement>) =>
-                    handleSetLanguage(e, normalizedLanguageCode)
-                  }
-                  label={label}
-                  lang={normalizedLanguageCode}
-                />
-              )
-            )}
+            {languages.map(normalizedLanguageCode => (
+              <Navigation.Item
+                key={normalizedLanguageCode}
+                href="#"
+                onClick={(e: React.SyntheticEvent<HTMLAnchorElement>) =>
+                  handleSetLanguage(e, normalizedLanguageCode)
+                }
+                label={t(`language.${normalizedLanguageCode}`)}
+                lang={normalizedLanguageCode}
+              />
+            ))}
           </Navigation.LanguageSelector>
           {isCreatingProfile && (
             <Navigation.Item

--- a/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`matches snapshot 1`] = `
               >
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="fi"
                 >
@@ -107,6 +108,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="sv"
                 >
@@ -118,6 +120,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="en"
                 >
@@ -129,6 +132,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="fr"
                 >
@@ -140,6 +144,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="ru"
                 >
@@ -151,6 +156,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="et"
                 >
@@ -162,6 +168,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="ltr"
                   href="#"
                   lang="so"
                 >
@@ -173,6 +180,7 @@ exports[`matches snapshot 1`] = `
                 </a>
                 <a
                   class="Menu-module_item__3yQdE "
+                  dir="rtl"
                   href="#"
                   lang="ar"
                 >

--- a/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -127,6 +127,61 @@ exports[`matches snapshot 1`] = `
                     English
                   </span>
                 </a>
+                <a
+                  class="Menu-module_item__3yQdE "
+                  href="#"
+                  lang="fr"
+                >
+                  <span
+                    class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                  >
+                    language.fr
+                  </span>
+                </a>
+                <a
+                  class="Menu-module_item__3yQdE "
+                  href="#"
+                  lang="ru"
+                >
+                  <span
+                    class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                  >
+                    language.ru
+                  </span>
+                </a>
+                <a
+                  class="Menu-module_item__3yQdE "
+                  href="#"
+                  lang="et"
+                >
+                  <span
+                    class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                  >
+                    language.et
+                  </span>
+                </a>
+                <a
+                  class="Menu-module_item__3yQdE "
+                  href="#"
+                  lang="so"
+                >
+                  <span
+                    class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                  >
+                    language.so
+                  </span>
+                </a>
+                <a
+                  class="Menu-module_item__3yQdE "
+                  href="#"
+                  lang="ar"
+                >
+                  <span
+                    class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                  >
+                    language.ar
+                  </span>
+                </a>
               </div>
             </div>
             <div

--- a/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/common/components/layout/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`matches snapshot 1`] = `
                   <span
                     class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                   >
-                    language.fr
+                    français
                   </span>
                 </a>
                 <a
@@ -146,7 +146,7 @@ exports[`matches snapshot 1`] = `
                   <span
                     class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                   >
-                    language.ru
+                    Русский язык
                   </span>
                 </a>
                 <a
@@ -157,7 +157,7 @@ exports[`matches snapshot 1`] = `
                   <span
                     class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                   >
-                    language.et
+                    eesti keel
                   </span>
                 </a>
                 <a
@@ -168,7 +168,7 @@ exports[`matches snapshot 1`] = `
                   <span
                     class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                   >
-                    language.so
+                    af Soomaali
                   </span>
                 </a>
                 <a
@@ -179,7 +179,7 @@ exports[`matches snapshot 1`] = `
                   <span
                     class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
                   >
-                    language.ar
+                    العربية
                   </span>
                 </a>
               </div>

--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -109,6 +109,10 @@ class I18nService {
   static get language(): Language {
     return i18n.language as Language;
   }
+
+  static dir(language?: string) {
+    return i18n.dir(language);
+  }
 }
 
 export default I18nService;

--- a/src/i18n/__tests__/I18nService.test.js
+++ b/src/i18n/__tests__/I18nService.test.js
@@ -36,6 +36,18 @@ describe('I18nService', () => {
     expect(i18n).toEqual(I18nService.get());
   });
 
+  describe('static method dir', () => {
+    it('static dir should return direction of language', () => {
+      expect(I18nService.dir('fi')).toEqual('ltr');
+      expect(I18nService.dir('ar')).toEqual('rtl');
+    });
+
+    it('static dir should return direction of current language if there are no arguments', () => {
+      expect(I18nService.language).toEqual('fi');
+      expect(I18nService.dir()).toEqual('ltr');
+    });
+  });
+
   describe('static init', () => {
     const replace = jest.fn();
     const fakeHistory = {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -76,6 +76,11 @@
     "SOMALI": "Somali",
     "SWEDISH": "Swedish"
   },
+  "language": {
+    "fi": "Suomi",
+    "sv": "Svenska",
+    "en": "English"
+  },
   "loading": "Loading...",
   "login": {
     "buttonText": "Get membership",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -79,7 +79,12 @@
   "language": {
     "fi": "Suomi",
     "sv": "Svenska",
-    "en": "English"
+    "en": "English",
+    "fr": "français",
+    "ru": "Русский язык",
+    "et": "eesti keel",
+    "so": "af Soomaali",
+    "ar": "العربية"
   },
   "loading": "Loading...",
   "login": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -79,7 +79,12 @@
   "language": {
     "fi": "Suomi",
     "sv": "Svenska",
-    "en": "English"
+    "en": "English",
+    "fr": "français",
+    "ru": "Русский язык",
+    "et": "eesti keel",
+    "so": "af Soomaali",
+    "ar": "العربية"
   },
   "loading": "Ladataan...",
   "login": {

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -76,6 +76,11 @@
     "SOMALI": "Somali",
     "SWEDISH": "Ruotsi"
   },
+  "language": {
+    "fi": "Suomi",
+    "sv": "Svenska",
+    "en": "English"
+  },
   "loading": "Ladataan...",
   "login": {
     "buttonText": "Hanki jäsenyys",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -76,6 +76,11 @@
     "SOMALI": "Somaliska",
     "SWEDISH": "Svenska"
   },
+  "language": {
+    "fi": "Suomi",
+    "sv": "Svenska",
+    "en": "English"
+  },
   "loading": "Laddar...",
   "login": {
     "buttonText": "Få medlemskap",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -79,7 +79,12 @@
   "language": {
     "fi": "Suomi",
     "sv": "Svenska",
-    "en": "English"
+    "en": "English",
+    "fr": "français",
+    "ru": "Русский язык",
+    "et": "eesti keel",
+    "so": "af Soomaali",
+    "ar": "العربية"
   },
   "loading": "Laddar...",
   "login": {


### PR DESCRIPTION
## Description

Instead of using hardcoded values, the navigation uses the I18nService to find out which languages are supported.

Also adds language direction support into the language navigation options.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-489](https://helsinkisolutionoffice.atlassian.net/browse/YM-489)
