### PR TITLE
YM-486 | Remove forced right aligns from text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - Feedback link into user survey
+- Hardcoded right aligns with text in order to better support right-to-left languages
 
 ## [1.3.1] - 2021-02-18
 

--- a/src/domain/auth/components/birthdateForm/BirthdateForm.module.css
+++ b/src/domain/auth/components/birthdateForm/BirthdateForm.module.css
@@ -1,5 +1,5 @@
 .birthdayForm {
-    text-align: left;
+    text-align: initial;
     width: auto;
     margin: 0 auto;
 }

--- a/src/domain/auth/components/login/Login.module.css
+++ b/src/domain/auth/components/login/Login.module.css
@@ -1,12 +1,7 @@
-.hostingBox {
-  text-align: left;
-}
-
 .helpText {
   margin: 20px 0 50px;
   font-size: var(--fontsize-body-l);
   line-height: var(--lineheight-m);
-  text-align: left;
 }
 
 .loginContainer {

--- a/src/domain/auth/components/login/Login.tsx
+++ b/src/domain/auth/components/login/Login.tsx
@@ -38,73 +38,67 @@ function Login() {
   return (
     <PageWrapper>
       <PageContentWithHostingBox title={'login.pageTitle'}>
-        <div className={styles.hostingBox}>
-          <Text variant="h1">{t('login.title')}</Text>
+        <Text variant="h1">{t('login.title')}</Text>
 
-          {!showManualRegistration && (
-            <React.Fragment>
-              <p className={styles.helpText}>{t('login.helpText')}</p>
-              <BirthdateForm redirectBasedOnAge={redirectBasedOnAge} />
+        {!showManualRegistration && (
+          <React.Fragment>
+            <p className={styles.helpText}>{t('login.helpText')}</p>
+            <BirthdateForm redirectBasedOnAge={redirectBasedOnAge} />
 
-              {!isAuthenticated && (
-                <div className={styles.loginContainer}>
-                  <span className={styles.linkForMembers}>
-                    {t('login.linkForMembersText')}
-                  </span>
-                  <Button
-                    onClick={() => authenticate()}
-                    variant="supplementary"
-                    className={styles.button}
-                    iconRight={null}
-                  >
-                    {t('nav.signin')}
-                  </Button>
-                </div>
-              )}
-            </React.Fragment>
-          )}
+            {!isAuthenticated && (
+              <div className={styles.loginContainer}>
+                <span className={styles.linkForMembers}>
+                  {t('login.linkForMembersText')}
+                </span>
+                <Button
+                  onClick={() => authenticate()}
+                  variant="supplementary"
+                  className={styles.button}
+                  iconRight={null}
+                >
+                  {t('nav.signin')}
+                </Button>
+              </div>
+            )}
+          </React.Fragment>
+        )}
 
-          {showManualRegistration && (
-            <div className={styles.loginContainer}>
-              <p className={styles.helpText}>{t('login.helpTextUnderAge')}</p>
-              <LinkButton
-                className={styles.linkButtons}
-                path={t('login.registrationForm')}
-                component="a"
-                buttonText={t('login.registrationFormText')}
-                variant="primary"
-                target="_blank"
-                rel="noopener noreferrer"
-                iconRight={
-                  <IconLinkExternal
-                    aria-label={t('externalLink.description')}
-                  />
-                }
-              />
-              <LinkButton
-                className={styles.linkButtons}
-                path={authConstants.URLS.YOUTH_CENTERS}
-                component="a"
-                buttonText={t('login.findNearestService')}
-                variant="primary"
-                iconRight={
-                  <IconLinkExternal
-                    aria-label={t('externalLink.description')}
-                  />
-                }
-              />
+        {showManualRegistration && (
+          <div className={styles.loginContainer}>
+            <p className={styles.helpText}>{t('login.helpTextUnderAge')}</p>
+            <LinkButton
+              className={styles.linkButtons}
+              path={t('login.registrationForm')}
+              component="a"
+              buttonText={t('login.registrationFormText')}
+              variant="primary"
+              target="_blank"
+              rel="noopener noreferrer"
+              iconRight={
+                <IconLinkExternal aria-label={t('externalLink.description')} />
+              }
+            />
+            <LinkButton
+              className={styles.linkButtons}
+              path={authConstants.URLS.YOUTH_CENTERS}
+              component="a"
+              buttonText={t('login.findNearestService')}
+              variant="primary"
+              iconRight={
+                <IconLinkExternal aria-label={t('externalLink.description')} />
+              }
+            />
 
-              <Button
-                test-id="goBack"
-                onClick={() => setShowManualRegistration(false)}
-                className={styles.linkButtons}
-                variant="secondary"
-              >
-                {t('login.return')}
-              </Button>
-            </div>
-          )}
-        </div>
+            <Button
+              test-id="goBack"
+              onClick={() => setShowManualRegistration(false)}
+              className={styles.linkButtons}
+              variant="secondary"
+            >
+              {t('login.return')}
+            </Button>
+          </div>
+        )}
       </PageContentWithHostingBox>
     </PageWrapper>
   );

--- a/src/domain/youthProfile/approve/approveYouthProfileForm.module.css
+++ b/src/domain/youthProfile/approve/approveYouthProfileForm.module.css
@@ -1,5 +1,5 @@
 .content {
-  text-align: left;
+  text-align: initial;
 }
 
 .formData, .formFields {

--- a/src/domain/youthProfile/create/createYouthProfile.module.css
+++ b/src/domain/youthProfile/create/createYouthProfile.module.css
@@ -1,11 +1,11 @@
 @media (min-width: 768px){
     .form {
-        text-align: left;
+        text-align: initial;
     }
 }
 
 .form {
-    text-align: left;
+    text-align: initial;
 }
 
 .loading {

--- a/src/domain/youthProfile/edit/editYouthProfile.module.css
+++ b/src/domain/youthProfile/edit/editYouthProfile.module.css
@@ -1,9 +1,9 @@
 @media (min-width: 768px){
     .form {
-        text-align: left;
+        text-align: initial;
     }
 }
 
 .form {
-    text-align: left;
+    text-align: initial;
 }

--- a/src/domain/youthProfile/form/youthProfileForm.module.css
+++ b/src/domain/youthProfile/form/youthProfileForm.module.css
@@ -101,7 +101,7 @@ a {
 
 @media (min-width: 768px) {
   .buttonAlign {
-    text-align: left;
+    text-align: initial;
   }
 }
 


### PR DESCRIPTION
## Description

Either removes text align entirely or replaces `left` values with `initial` values, which allows the styling logic to correctly decide the non-centered text state based on the `dir` attribute in the html element.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-486](https://helsinkisolutionoffice.atlassian.net/browse/YM-486)

## How Has This Been Tested?

I've tested the views manually. I wasn't able to test the approver view because mails still seem to have some issues.
