### PR TITLE
YM-493 | Register locales within I18nService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Option to define additional locales with environment variables
 - Support for language direction detection based on locale
 
+### Changed
+
+- Country select to dynamically find supported languages from the I18nService
+
 ### Fixed
 
 - Approval process always allowing photo usage regardless of choice

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "hds-design-tokens": "0.20.0",
     "hds-react": "0.20.0",
     "helsinki-utils": "City-of-Helsinki/helsinki-utils-js#0.1.0",
-    "i18n-iso-countries": "^5.3.0",
+    "i18n-iso-countries": "6.5.0",
     "i18next": "^17.3.0",
     "i18next-browser-languagedetector": "^4.0.1",
     "lodash": "^4.17.19",

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -3,10 +3,6 @@ import { ApolloProvider } from '@apollo/client';
 import { Provider as ReduxProvider } from 'react-redux';
 import { OidcProvider, loadUser } from 'redux-oidc';
 import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react';
-import countries from 'i18n-iso-countries';
-import fi from 'i18n-iso-countries/langs/fi.json';
-import en from 'i18n-iso-countries/langs/en.json';
-import sv from 'i18n-iso-countries/langs/sv.json';
 import { HelmetProvider } from 'react-helmet-async';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -24,10 +20,6 @@ import AppMeta from './AppMeta';
 import AppRoutes from './AppRoutes';
 import AppTitleAnnouncer from './AppTitleAnnouncer';
 import styles from './app.module.css';
-
-countries.registerLocale(fi);
-countries.registerLocale(en);
-countries.registerLocale(sv);
 
 if (process.env.NODE_ENV !== 'production') {
   enableOidcLogging();

--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -2,6 +2,7 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import * as H from 'history';
+import countries from 'i18n-iso-countries';
 
 import * as PathUtils from '../common/reactRouterWithLanguageSupport/pathUtils';
 import Config from '../config';
@@ -53,12 +54,33 @@ function getResources(locales: string[]) {
   return { ...defaultResources, ...additionalResources };
 }
 
+function registerLocale(languageCode: string) {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const language = require(`i18n-iso-countries/langs/${languageCode}.json`);
+
+    countries.registerLocale(language);
+  } catch (e) {
+    Logger.error(
+      `The i18n-iso-countries package does not have support for locale ${languageCode}`
+    );
+  }
+}
+
+function registerLocales(locales: string[]) {
+  locales.forEach(locale => {
+    registerLocale(locale);
+  });
+}
+
 class I18nService {
   static get languages() {
     return [...defaultLanguages, ...Config.additionalLocales];
   }
 
   static init(history: H.History) {
+    registerLocales(this.languages);
+
     const resources = getResources(this.languages);
 
     // Set languageChanged for direction event before initialization so

--- a/src/i18n/I18nService.ts
+++ b/src/i18n/I18nService.ts
@@ -7,9 +7,6 @@ import countries from 'i18n-iso-countries';
 import * as PathUtils from '../common/reactRouterWithLanguageSupport/pathUtils';
 import Config from '../config';
 import Logger from '../logger';
-import en from './en.json';
-import fi from './fi.json';
-import sv from './sv.json';
 import setYupLocale from './setYupLocale';
 
 const defaultLanguages = ['fi', 'sv', 'en'];
@@ -29,29 +26,18 @@ function getLanguage(languageCode: string) {
 }
 
 function getResources(locales: string[]) {
-  const defaultResources = {
-    en: {
-      translation: en,
-    },
-    fi: {
-      translation: fi,
-    },
-    sv: {
-      translation: sv,
-    },
-  };
-  const additionalResources = locales.reduce((additionalResources, locale) => {
+  const resources = locales.reduce((resources, locale) => {
     const resource = getLanguage(locale);
 
     return {
-      ...additionalResources,
+      ...resources,
       [locale]: {
         translation: resource,
       },
     };
   }, {});
 
-  return { ...defaultResources, ...additionalResources };
+  return resources;
 }
 
 function registerLocale(languageCode: string) {

--- a/src/i18n/__tests__/I18nService.test.js
+++ b/src/i18n/__tests__/I18nService.test.js
@@ -97,9 +97,7 @@ describe('I18nService', () => {
 
       I18nService.init(fakeHistory);
 
-      // Somali is lacking support in the i18n-iso-countries library so
-      // it is not loaded
-      expect(registerLocaleSpy).toHaveBeenCalledTimes(7);
+      expect(registerLocaleSpy).toHaveBeenCalledTimes(8);
     });
 
     it('should configure i18next', () => {

--- a/src/i18n/__tests__/I18nService.test.js
+++ b/src/i18n/__tests__/I18nService.test.js
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import countries from 'i18n-iso-countries';
 
 import setYupLocale from '../setYupLocale';
 import I18nService from '../I18nService';
@@ -85,6 +86,20 @@ describe('I18nService', () => {
       I18nService.get().changeLanguage('ar');
 
       expect(dirSpy).toHaveBeenCalledWith('rtl');
+    });
+
+    it('should register locales for i18n-iso-countries', () => {
+      // Use a spy because the library behaves in the way it does when
+      // it is used in a NodeJS project instead of a browser project.
+      // In other words, the library is automatically configured to
+      // return all languages.
+      const registerLocaleSpy = jest.spyOn(countries, 'registerLocale');
+
+      I18nService.init(fakeHistory);
+
+      // Somali is lacking support in the i18n-iso-countries library so
+      // it is not loaded
+      expect(registerLocaleSpy).toHaveBeenCalledTimes(7);
     });
 
     it('should configure i18next', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8810,10 +8810,10 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-i18n-iso-countries@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-5.3.0.tgz#254e32f5476ba0381eb9da58a51abfd01a7fd90d"
-  integrity sha512-Ud3lP2ByK8y5gpy8kFuq7I+EmYF/S+K0dSi/2l+G3Gwk8/ZMTtjUGXEvvwmSLsm1Mx00VTmtGMbkR6fua/rdGg==
+i18n-iso-countries@6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/i18n-iso-countries/-/i18n-iso-countries-6.5.0.tgz#0fb3f6fcc8e9f67a2ce907cdc92efb48e2ccd8f6"
+  integrity sha512-9cQv5DnAaaEoRohH3RuN6l+GEEk8QtTLalg1D9ngIC7oKCKqqWKKFIWUMazpECAD7mzQAZhXpo2pLXnF6IiyZA==
   dependencies:
     diacritics "1.3.0"
 


### PR DESCRIPTION
## Description

After these changes, locales are registered within the I18nService, according to the supported languages. This integrates the i18n-iso-countries library into our I18nService, giving the country select the possibility to show options in supported languages.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-493](https://helsinkisolutionoffice.atlassian.net/browse/YM-493)
