### PR TITLE
YM-490 | Add placeholder translations for fr, ru, et, so and ar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Logic to handle the renewing membership status
 - Option to define additional locales with environment variables
 - Support for language direction detection based on locale
+- Placeholder translations for French, Russian, Estonian, Somali and Arabic
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ci": "yarn setPackageDetails CI=true yarn test --coverage",
     "lint": "eslint --ext js,ts,tsx src",
     "codegen": "apollo client:codegen ./src/graphql/generatedTypes.ts --outputFlat --includes=./src/**/*.graphql --target=typescript --endpoint=https://jassari-federation.test.kuva.hel.ninja/ --useReadOnlyTypes --addTypename",
-    "update-translations": "fetch-translations 14aAzZeJ0HijXy7LklBtvOr0LKNy8PrpR2Gf_4ryv668 -l fi,en,sv -o ./src/i18n",
+    "update-translations": "fetch-translations 14aAzZeJ0HijXy7LklBtvOr0LKNy8PrpR2Gf_4ryv668 -l fi,en,sv,fr,ru,et,so,ar -o ./src/i18n",
     "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
     "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true",
     "setPackageDetails": "cross-env REACT_APP_VERSION=$npm_package_version REACT_APP_APPLICATION_NAME=$npm_package_name"

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -1,0 +1,281 @@
+{
+  "appName": "AR_Jässäri",
+  "approval": {
+    "addGuardianText": "AR_Other added guardians may be contacted in matters concerning the child.",
+    "addInfo": "AR_Additional info",
+    "additionalAddresses": "AR_Additional addresses",
+    "address": "AR_Home address",
+    "approveButton": "AR_Approve membership",
+    "approvedLink": "AR_The link has expired",
+    "approvedMessage": "AR_Thank you for confirming youth service membership.",
+    "approvedTitle": "AR_Jässäri membership approved!",
+    "approverAcceptance": "AR_Permissions to be approved",
+    "approverEmail": "AR_Email",
+    "approverFirstName": "AR_Firstname",
+    "approverInfo": "AR_Approver info",
+    "approverInfoText": "AR_Guardian may be contacted concerning the child.",
+    "approverLastName": "AR_Lastname",
+    "approveTerms": "AR_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "approveTermsText_link": "AR_service terms",
+    "basicInfo": "AR_Basic info",
+    "birthDate": "AR_Birthdate",
+    "explanationCheckStatus": "AR_The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "AR_You have either already approved the application submitted by your youth or an error has occurred in our service.",
+    "formExplanationText_1": "AR_has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
+    "formExplanationText_2": "AR_may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
+    "languagesAtHome": "AR_Languages at home",
+    "name": "AR_Name",
+    "phone": "AR_Phone",
+    "photoUsageApproved": "AR_Photo usage approval",
+    "photoUsageApprovedNo": "AR_No",
+    "photoUsageApprovedText": "AR_The young person may be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "AR_Yes",
+    "profile": "AR_Profile",
+    "schoolInfo": "AR_School and class",
+    "title": "AR_Please approve membership"
+  },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "AR_Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "errorMessage": "AR_An error occured while logging in. Please try again",
+    "errorTitle": "AR_Oops!",
+    "permRequestDenied": {
+      "message": "AR_You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    }
+  },
+  "confirmSendingProfile": {
+    "buttonText": "AR_Send a new request to the guardian",
+    "helpText": "AR_Your membership application has been sent to",
+    "linkToShowSentData": "AR_Display your application",
+    "sendAgainHelpText": "AR_Approval email has been re-sent to",
+    "title": "AR_The application has been sent to your guardian for approval!"
+  },
+  "edit": {
+    "pageTitle": "AR_Edit own information"
+  },
+  "emailApproval": {
+    "content": "AR_Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "AR_{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "AR_Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "AR_{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "AR_Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "AR_{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
+  "externalLink": {
+    "description": "AR_Opens in a new window"
+  },
+  "fields": {
+    "city": "AR_a city",
+    "email": "AR_an email",
+    "firstName": "AR_a first name",
+    "lastName": "AR_a last name",
+    "phoneNumber": "AR_a phone number",
+    "photoUsageApproved": "AR_photo usage approval",
+    "postalCode": "AR_a postal code",
+    "schoolClass": "AR_a school class",
+    "schoolName": "AR_a school name",
+    "streetAddress": "AR_a street address"
+  },
+  "footer": {
+    "accessibility": "AR_Accessibility document",
+    "copyright": "AR_City of Helsinki",
+    "feedback": "AR_Give feedback",
+    "feedbackLink": "AR_https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/en/feedback/feedback/",
+    "privacy": "AR_Privacy policy",
+    "reserveRights": "AR_All rights reserved",
+    "terms": "AR_Terms of Service"
+  },
+  "helsinkiLogo": "AR_Helsinki logo",
+  "LANGUAGE_OPTIONS": {
+    "ARABIC": "AR_Arabic",
+    "ENGLISH": "AR_English",
+    "ESTONIAN": "AR_Estonian",
+    "FINNISH": "AR_Finnish",
+    "RUSSIAN": "AR_Russian",
+    "SOMALI": "AR_Somali",
+    "SWEDISH": "AR_Swedish"
+  },
+  "language": {
+    "ar": "AR_العربية",
+    "en": "AR_English",
+    "et": "AR_eesti keel",
+    "fi": "AR_Suomi",
+    "fr": "AR_français",
+    "ru": "AR_Русский язык",
+    "so": "AR_af Soomaali",
+    "sv": "AR_Svenska"
+  },
+  "loading": "AR_Loading...",
+  "login": {
+    "buttonText": "AR_Get membership",
+    "findNearestService": "AR_Find the nearest youth centre on the service map",
+    "helpText": "AR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "helpTextUnderAge": "AR_Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
+    "linkForMembersText": "AR_Do you have membership? Log in",
+    "pageTitle": "AR_Youth membership card",
+    "registrationForm": "AR_http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
+    "registrationFormText": "AR_Download application form",
+    "return": "AR_Go back",
+    "title": "AR_Get your Jässäri!"
+  },
+  "membershipDetails": {
+    "additionalInformation": "AR_Additional information",
+    "edit": "AR_Edit information",
+    "photoUsageExplanation": "AR_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "profileInformation": "AR_Basic information",
+    "requiredPermissionsFromParent": "AR_Required permissions from parent",
+    "returnToFront": "AR_Return to frontpage",
+    "text": "AR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "title": "AR_Own information"
+  },
+  "membershipInformation": {
+    "pageTitle": "AR_Membership information",
+    "renew": "AR_Renew membership",
+    "renewSuccessMessage": "AR_Membership renewed successfully!",
+    "renewSuccessMessageMinor": "AR_Renewal request sent successfully!",
+    "renewSuccessTitle": "AR_Success",
+    "renewUnderage": "AR_Send a renewal request to the guardian",
+    "showProfileInformation": "AR_Show profile information",
+    "status": {
+      "description": {
+        "expired": "AR_Resubmit your membership to your guardian for approval.",
+        "pending": "AR_Your renewal request has been sent to {{email}}",
+        "renewable": "AR_Resubmit your membership to your guardian for approval.",
+        "renewing": "AR_Your renewal request has been sent to {{email}}"
+      },
+      "title": {
+        "membershipExpired": "AR_Membership has expired.",
+        "pending": "AR_Renewal of membership is awaiting for guardian approval.",
+        "renewable": "AR_Membership expires on {{date}}.",
+        "renewing": "AR_Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      }
+    },
+    "title": "AR_Membership card number {{number}}",
+    "validUntil": "AR_Valid until {{date}}"
+  },
+  "meta": {
+    "description": "AR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
+  },
+  "nav": {
+    "helsinki": "AR_Helsinki",
+    "menu": "AR_Menu",
+    "menuButtonLabel": "AR_Profile menu",
+    "profile": "AR_Helsinki Profile",
+    "signin": "AR_Log in",
+    "signout": "AR_Log out",
+    "skipToContent": "AR_Skip to main content"
+  },
+  "notification": {
+    "closeButtonText": "AR_Close",
+    "defaultErrorText": "AR_Something went wrong. Try again after a while.",
+    "defaultErrorTitle": "AR_Error"
+  },
+  "oidc": {
+    "authenticating": "AR_Authenticating..."
+  },
+  "privacyPolicy": {
+    "descriptionLink": "AR_https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "AR_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
+  },
+  "profile": {
+    "address": "AR_Address",
+    "email": "AR_Email",
+    "loading": "AR_Loading profile...",
+    "name": "AR_Name",
+    "phone": "AR_Phone",
+    "verifying": "AR_Checking profile..."
+  },
+  "registration": {
+    "addAddress": "AR_Add another address",
+    "addGuardian": "AR_Add another guardian's information ",
+    "addGuardianText": "AR_If necessary other guardians may be contacted in matters relating to your youth membership.",
+    "addInfo": "AR_Additional info",
+    "address": "AR_Street",
+    "ageRestriction": "AR_Jässäri is only for youths between 8-29 years.",
+    "approver": "AR_Approver",
+    "approverInfoOver18Text": "AR_For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
+    "approverInfoText": "AR_A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
+    "approveTerms": "AR_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "basicInfo": "AR_Basic info",
+    "birthdayHelper": "AR_Birthdate (dd.mm.yyyy) *",
+    "birthdayInvalid": "AR_The birthday should be dd.mm.yyyy.",
+    "cancel": "AR_Cancel",
+    "childBirthDay": "AR_Birthdate",
+    "childBirthMonth": "AR_Birthmonth",
+    "childBirthYear": "AR_Birthyear",
+    "city": "AR_City",
+    "confirmSend": "AR_Accept the terms and send the application",
+    "country": "AR_Country",
+    "date": "AR_Date",
+    "dateInvalid": "AR_Invalid date",
+    "email": "AR_Email",
+    "firstName": "AR_First name",
+    "languageAtHome": "AR_Language at home",
+    "lastName": "AR_Last name",
+    "membershipInfoText": "AR_Membership is free and does not require anything of you, but you do need a membership to be able to participate in activities at Youth Centres. We will not disclose your information to third parties. You have the right to check and remove the information we have stored concerning you. Please remember that intoxicants are not allowed at Youth Centre activities. ",
+    "month": "AR_Month",
+    "pageTitle": "AR_Create profile",
+    "phoneNumber": "AR_Phone",
+    "photoUsageApproved": "AR_Photo usage approved",
+    "photoUsageApprovedNo": "AR_No",
+    "photoUsageApprovedText": "AR_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "AR_Yes",
+    "postalCode": "AR_Postal code",
+    "processInfoText": "AR_A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
+    "profileLanguage": "AR_Profile language",
+    "remove": "AR_Delete",
+    "save": "AR_Save information",
+    "schoolClass": "AR_School class",
+    "schoolName": "AR_School name",
+    "sendButton": "AR_Save and send approval request",
+    "title": "AR_Please fill in your information",
+    "year": "AR_Year"
+  },
+  "registry": {
+    "descriptionLink": "AR_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
+  },
+  "sanityCheck": "AR_youth-profile.en",
+  "tos": {
+    "message1": "AR_Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "message2": "AR_",
+    "message3": "AR_",
+    "message4": "AR_",
+    "message5": "AR_",
+    "message6": "AR_",
+    "message7": "AR_",
+    "message8": "AR_",
+    "title": "AR_Terms of Service",
+    "title1": "AR_1. Scope of application",
+    "title2": "AR_2. Create and disable a profile",
+    "title3": "AR_3. Using a profile",
+    "title4": "AR_4. Availability of the service",
+    "title5": "AR_5. Personal information",
+    "title6": "AR_6. Rights",
+    "title7": "AR_7. Limitation of Liability",
+    "title8": "AR_8. Other terms and conditions",
+    "updated": "AR_Updated 20.1.2020"
+  },
+  "validation": {
+    "email": "AR_Please enter a valid email address",
+    "invalidPostalCode": "AR_Please enter a valid postal code",
+    "required": "AR_Please enter {{label}}",
+    "requiredTerms": "AR_Please accept the terms",
+    "tooLong": "AR_Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "AR_Please enter {{label}} that's more than {{min}} characters long"
+  },
+  "youthProfile": {
+    "approverEmail": "AR_Email",
+    "approverInfo": "AR_Approver information",
+    "approverName": "AR_Name",
+    "approverPhone": "AR_Phone",
+    "birthdate": "AR_Birthdate",
+    "homeLanguages": "AR_Language spoken at home",
+    "school": "AR_School"
+  },
+  "": "AR_"
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -19,8 +19,8 @@
     "approveTermsText_link": "service terms",
     "basicInfo": "Basic info",
     "birthDate": "Birthdate",
-    "explanationError": "You have either already approved the application submitted by your youth or an error has occurred in our service.",
     "explanationCheckStatus": "The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "You have either already approved the application submitted by your youth or an error has occurred in our service.",
     "formExplanationText_1": "has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
     "formExplanationText_2": "may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
     "languagesAtHome": "Languages at home",
@@ -38,11 +38,11 @@
     "deviceTimeError": {
       "message": "Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
     },
+    "errorMessage": "An error occured while logging in. Please try again",
+    "errorTitle": "Oops!",
     "permRequestDenied": {
       "message": "You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
-    },
-    "errorTitle": "Oops!",
-    "errorMessage": "An error occured while logging in. Please try again"
+    }
   },
   "confirmSendingProfile": {
     "buttonText": "Send a new request to the guardian",
@@ -54,8 +54,32 @@
   "edit": {
     "pageTitle": "Edit own information"
   },
+  "emailApproval": {
+    "content": "Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
   "externalLink": {
     "description": "Opens in a new window"
+  },
+  "fields": {
+    "city": "a city",
+    "email": "an email",
+    "firstName": "a first name",
+    "lastName": "a last name",
+    "phoneNumber": "a phone number",
+    "photoUsageApproved": "photo usage approval",
+    "postalCode": "a postal code",
+    "schoolClass": "a school class",
+    "schoolName": "a school name",
+    "streetAddress": "a street address"
   },
   "footer": {
     "accessibility": "Accessibility document",
@@ -77,14 +101,14 @@
     "SWEDISH": "Swedish"
   },
   "language": {
-    "fi": "Suomi",
-    "sv": "Svenska",
+    "ar": "العربية",
     "en": "English",
+    "et": "eesti keel",
+    "fi": "Suomi",
     "fr": "français",
     "ru": "Русский язык",
-    "et": "eesti keel",
     "so": "af Soomaali",
-    "ar": "العربية"
+    "sv": "Svenska"
   },
   "loading": "Loading...",
   "login": {
@@ -93,10 +117,10 @@
     "helpText": "Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
     "helpTextUnderAge": "Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
     "linkForMembersText": "Do you have membership? Log in",
+    "pageTitle": "Youth membership card",
     "registrationForm": "http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
     "registrationFormText": "Download application form",
     "return": "Go back",
-    "pageTitle": "Youth membership card",
     "title": "Get your Jässäri!"
   },
   "membershipDetails": {
@@ -112,39 +136,39 @@
   "membershipInformation": {
     "pageTitle": "Membership information",
     "renew": "Renew membership",
-    "renewUnderage": "Send a renewal request to the guardian",
     "renewSuccessMessage": "Membership renewed successfully!",
     "renewSuccessMessageMinor": "Renewal request sent successfully!",
     "renewSuccessTitle": "Success",
+    "renewUnderage": "Send a renewal request to the guardian",
     "showProfileInformation": "Show profile information",
-    "title": "Membership card number {{number}}",
-    "validUntil": "Valid until {{date}}",
     "status": {
+      "description": {
+        "expired": "Resubmit your membership to your guardian for approval.",
+        "pending": "Your renewal request has been sent to {{email}}",
+        "renewable": "Resubmit your membership to your guardian for approval.",
+        "renewing": "Your renewal request has been sent to {{email}}"
+      },
       "title": {
         "membershipExpired": "Membership has expired.",
-        "renewable": "Membership expires on {{date}}.",
         "pending": "Renewal of membership is awaiting for guardian approval.",
+        "renewable": "Membership expires on {{date}}.",
         "renewing": "Membership expires on {{date}}. Renewal is awaiting guardian approval."
-      },
-      "description": {
-        "renewable": "Resubmit your membership to your guardian for approval.",
-        "pending": "Your renewal request has been sent to {{email}}",
-        "renewing": "Your renewal request has been sent to {{email}}",
-        "expired": "Resubmit your membership to your guardian for approval."
       }
-    }
+    },
+    "title": "Membership card number {{number}}",
+    "validUntil": "Valid until {{date}}"
   },
   "meta": {
     "description": "Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
   },
   "nav": {
+    "helsinki": "Helsinki",
+    "menu": "Menu",
     "menuButtonLabel": "Profile menu",
     "profile": "Helsinki Profile",
     "signin": "Log in",
     "signout": "Log out",
-    "menu": "Menu",
-    "skipToContent": "Skip to main content",
-    "helsinki": "Helsinki"
+    "skipToContent": "Skip to main content"
   },
   "notification": {
     "closeButtonText": "Close",
@@ -167,6 +191,9 @@
     "verifying": "Checking profile..."
   },
   "registration": {
+    "addAddress": "Add another address",
+    "addGuardian": "Add another guardian's information ",
+    "addGuardianText": "If necessary other guardians may be contacted in matters relating to your youth membership.",
     "addInfo": "Additional info",
     "address": "Street",
     "ageRestriction": "Jässäri is only for youths between 8-29 years.",
@@ -201,16 +228,13 @@
     "postalCode": "Postal code",
     "processInfoText": "A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
     "profileLanguage": "Profile language",
+    "remove": "Delete",
     "save": "Save information",
     "schoolClass": "School class",
     "schoolName": "School name",
     "sendButton": "Save and send approval request",
     "title": "Please fill in your information",
-    "year": "Year",
-    "addAddress": "Add another address",
-    "addGuardian": "Add another guardian's information ",
-    "addGuardianText": "If necessary other guardians may be contacted in matters relating to your youth membership.",
-    "remove": "Delete"
+    "year": "Year"
   },
   "registry": {
     "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
@@ -239,8 +263,8 @@
   "validation": {
     "email": "Please enter a valid email address",
     "invalidPostalCode": "Please enter a valid postal code",
-    "requiredTerms": "Please accept the terms",
     "required": "Please enter {{label}}",
+    "requiredTerms": "Please accept the terms",
     "tooLong": "Please enter {{label}} that's less than {{max}} characters long",
     "tooShort": "Please enter {{label}} that's more than {{min}} characters long"
   },
@@ -252,29 +276,5 @@
     "birthdate": "Birthdate",
     "homeLanguages": "Language spoken at home",
     "school": "School"
-  },
-  "emailApproval": {
-    "heading": "{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval.",
-    "content": "Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>"
-  },
-  "emailApproved": {
-    "heading": "{{ youth_profile.approver_first_name }} has approved your Youth Services membership",
-    "content": "Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>"
-  },
-  "emailRenew": {
-    "heading": "{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire",
-    "content": "Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>"
-  },
-  "fields": {
-    "firstName": "a first name",
-    "lastName": "a last name",
-    "streetAddress": "a street address",
-    "postalCode": "a postal code",
-    "city": "a city",
-    "phoneNumber": "a phone number",
-    "email": "an email",
-    "schoolName": "a school name",
-    "schoolClass": "a school class",
-    "photoUsageApproved": "photo usage approval"
   }
 }

--- a/src/i18n/et.json
+++ b/src/i18n/et.json
@@ -1,0 +1,281 @@
+{
+  "appName": "ET_Jässäri",
+  "approval": {
+    "addGuardianText": "ET_Other added guardians may be contacted in matters concerning the child.",
+    "addInfo": "ET_Additional info",
+    "additionalAddresses": "ET_Additional addresses",
+    "address": "ET_Home address",
+    "approveButton": "ET_Approve membership",
+    "approvedLink": "ET_The link has expired",
+    "approvedMessage": "ET_Thank you for confirming youth service membership.",
+    "approvedTitle": "ET_Jässäri membership approved!",
+    "approverAcceptance": "ET_Permissions to be approved",
+    "approverEmail": "ET_Email",
+    "approverFirstName": "ET_Firstname",
+    "approverInfo": "ET_Approver info",
+    "approverInfoText": "ET_Guardian may be contacted concerning the child.",
+    "approverLastName": "ET_Lastname",
+    "approveTerms": "ET_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "approveTermsText_link": "ET_service terms",
+    "basicInfo": "ET_Basic info",
+    "birthDate": "ET_Birthdate",
+    "explanationCheckStatus": "ET_The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "ET_You have either already approved the application submitted by your youth or an error has occurred in our service.",
+    "formExplanationText_1": "ET_has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
+    "formExplanationText_2": "ET_may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
+    "languagesAtHome": "ET_Languages at home",
+    "name": "ET_Name",
+    "phone": "ET_Phone",
+    "photoUsageApproved": "ET_Photo usage approval",
+    "photoUsageApprovedNo": "ET_No",
+    "photoUsageApprovedText": "ET_The young person may be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "ET_Yes",
+    "profile": "ET_Profile",
+    "schoolInfo": "ET_School and class",
+    "title": "ET_Please approve membership"
+  },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "ET_Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "errorMessage": "ET_An error occured while logging in. Please try again",
+    "errorTitle": "ET_Oops!",
+    "permRequestDenied": {
+      "message": "ET_You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    }
+  },
+  "confirmSendingProfile": {
+    "buttonText": "ET_Send a new request to the guardian",
+    "helpText": "ET_Your membership application has been sent to",
+    "linkToShowSentData": "ET_Display your application",
+    "sendAgainHelpText": "ET_Approval email has been re-sent to",
+    "title": "ET_The application has been sent to your guardian for approval!"
+  },
+  "edit": {
+    "pageTitle": "ET_Edit own information"
+  },
+  "emailApproval": {
+    "content": "ET_Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "ET_{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "ET_Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "ET_{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "ET_Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "ET_{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
+  "externalLink": {
+    "description": "ET_Opens in a new window"
+  },
+  "fields": {
+    "city": "ET_a city",
+    "email": "ET_an email",
+    "firstName": "ET_a first name",
+    "lastName": "ET_a last name",
+    "phoneNumber": "ET_a phone number",
+    "photoUsageApproved": "ET_photo usage approval",
+    "postalCode": "ET_a postal code",
+    "schoolClass": "ET_a school class",
+    "schoolName": "ET_a school name",
+    "streetAddress": "ET_a street address"
+  },
+  "footer": {
+    "accessibility": "ET_Accessibility document",
+    "copyright": "ET_City of Helsinki",
+    "feedback": "ET_Give feedback",
+    "feedbackLink": "ET_https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/en/feedback/feedback/",
+    "privacy": "ET_Privacy policy",
+    "reserveRights": "ET_All rights reserved",
+    "terms": "ET_Terms of Service"
+  },
+  "helsinkiLogo": "ET_Helsinki logo",
+  "LANGUAGE_OPTIONS": {
+    "ARABIC": "ET_Arabic",
+    "ENGLISH": "ET_English",
+    "ESTONIAN": "ET_Estonian",
+    "FINNISH": "ET_Finnish",
+    "RUSSIAN": "ET_Russian",
+    "SOMALI": "ET_Somali",
+    "SWEDISH": "ET_Swedish"
+  },
+  "language": {
+    "ar": "ET_العربية",
+    "en": "ET_English",
+    "et": "ET_eesti keel",
+    "fi": "ET_Suomi",
+    "fr": "ET_français",
+    "ru": "ET_Русский язык",
+    "so": "ET_af Soomaali",
+    "sv": "ET_Svenska"
+  },
+  "loading": "ET_Loading...",
+  "login": {
+    "buttonText": "ET_Get membership",
+    "findNearestService": "ET_Find the nearest youth centre on the service map",
+    "helpText": "ET_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "helpTextUnderAge": "ET_Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
+    "linkForMembersText": "ET_Do you have membership? Log in",
+    "pageTitle": "ET_Youth membership card",
+    "registrationForm": "ET_http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
+    "registrationFormText": "ET_Download application form",
+    "return": "ET_Go back",
+    "title": "ET_Get your Jässäri!"
+  },
+  "membershipDetails": {
+    "additionalInformation": "ET_Additional information",
+    "edit": "ET_Edit information",
+    "photoUsageExplanation": "ET_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "profileInformation": "ET_Basic information",
+    "requiredPermissionsFromParent": "ET_Required permissions from parent",
+    "returnToFront": "ET_Return to frontpage",
+    "text": "ET_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "title": "ET_Own information"
+  },
+  "membershipInformation": {
+    "pageTitle": "ET_Membership information",
+    "renew": "ET_Renew membership",
+    "renewSuccessMessage": "ET_Membership renewed successfully!",
+    "renewSuccessMessageMinor": "ET_Renewal request sent successfully!",
+    "renewSuccessTitle": "ET_Success",
+    "renewUnderage": "ET_Send a renewal request to the guardian",
+    "showProfileInformation": "ET_Show profile information",
+    "status": {
+      "description": {
+        "expired": "ET_Resubmit your membership to your guardian for approval.",
+        "pending": "ET_Your renewal request has been sent to {{email}}",
+        "renewable": "ET_Resubmit your membership to your guardian for approval.",
+        "renewing": "ET_Your renewal request has been sent to {{email}}"
+      },
+      "title": {
+        "membershipExpired": "ET_Membership has expired.",
+        "pending": "ET_Renewal of membership is awaiting for guardian approval.",
+        "renewable": "ET_Membership expires on {{date}}.",
+        "renewing": "ET_Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      }
+    },
+    "title": "ET_Membership card number {{number}}",
+    "validUntil": "ET_Valid until {{date}}"
+  },
+  "meta": {
+    "description": "ET_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
+  },
+  "nav": {
+    "helsinki": "ET_Helsinki",
+    "menu": "ET_Menu",
+    "menuButtonLabel": "ET_Profile menu",
+    "profile": "ET_Helsinki Profile",
+    "signin": "ET_Log in",
+    "signout": "ET_Log out",
+    "skipToContent": "ET_Skip to main content"
+  },
+  "notification": {
+    "closeButtonText": "ET_Close",
+    "defaultErrorText": "ET_Something went wrong. Try again after a while.",
+    "defaultErrorTitle": "ET_Error"
+  },
+  "oidc": {
+    "authenticating": "ET_Authenticating..."
+  },
+  "privacyPolicy": {
+    "descriptionLink": "ET_https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "ET_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
+  },
+  "profile": {
+    "address": "ET_Address",
+    "email": "ET_Email",
+    "loading": "ET_Loading profile...",
+    "name": "ET_Name",
+    "phone": "ET_Phone",
+    "verifying": "ET_Checking profile..."
+  },
+  "registration": {
+    "addAddress": "ET_Add another address",
+    "addGuardian": "ET_Add another guardian's information ",
+    "addGuardianText": "ET_If necessary other guardians may be contacted in matters relating to your youth membership.",
+    "addInfo": "ET_Additional info",
+    "address": "ET_Street",
+    "ageRestriction": "ET_Jässäri is only for youths between 8-29 years.",
+    "approver": "ET_Approver",
+    "approverInfoOver18Text": "ET_For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
+    "approverInfoText": "ET_A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
+    "approveTerms": "ET_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "basicInfo": "ET_Basic info",
+    "birthdayHelper": "ET_Birthdate (dd.mm.yyyy) *",
+    "birthdayInvalid": "ET_The birthday should be dd.mm.yyyy.",
+    "cancel": "ET_Cancel",
+    "childBirthDay": "ET_Birthdate",
+    "childBirthMonth": "ET_Birthmonth",
+    "childBirthYear": "ET_Birthyear",
+    "city": "ET_City",
+    "confirmSend": "ET_Accept the terms and send the application",
+    "country": "ET_Country",
+    "date": "ET_Date",
+    "dateInvalid": "ET_Invalid date",
+    "email": "ET_Email",
+    "firstName": "ET_First name",
+    "languageAtHome": "ET_Language at home",
+    "lastName": "ET_Last name",
+    "membershipInfoText": "ET_Membership is free and does not require anything of you, but you do need a membership to be able to participate in activities at Youth Centres. We will not disclose your information to third parties. You have the right to check and remove the information we have stored concerning you. Please remember that intoxicants are not allowed at Youth Centre activities. ",
+    "month": "ET_Month",
+    "pageTitle": "ET_Create profile",
+    "phoneNumber": "ET_Phone",
+    "photoUsageApproved": "ET_Photo usage approved",
+    "photoUsageApprovedNo": "ET_No",
+    "photoUsageApprovedText": "ET_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "ET_Yes",
+    "postalCode": "ET_Postal code",
+    "processInfoText": "ET_A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
+    "profileLanguage": "ET_Profile language",
+    "remove": "ET_Delete",
+    "save": "ET_Save information",
+    "schoolClass": "ET_School class",
+    "schoolName": "ET_School name",
+    "sendButton": "ET_Save and send approval request",
+    "title": "ET_Please fill in your information",
+    "year": "ET_Year"
+  },
+  "registry": {
+    "descriptionLink": "ET_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
+  },
+  "sanityCheck": "ET_youth-profile.en",
+  "tos": {
+    "message1": "ET_Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "message2": "ET_",
+    "message3": "ET_",
+    "message4": "ET_",
+    "message5": "ET_",
+    "message6": "ET_",
+    "message7": "ET_",
+    "message8": "ET_",
+    "title": "ET_Terms of Service",
+    "title1": "ET_1. Scope of application",
+    "title2": "ET_2. Create and disable a profile",
+    "title3": "ET_3. Using a profile",
+    "title4": "ET_4. Availability of the service",
+    "title5": "ET_5. Personal information",
+    "title6": "ET_6. Rights",
+    "title7": "ET_7. Limitation of Liability",
+    "title8": "ET_8. Other terms and conditions",
+    "updated": "ET_Updated 20.1.2020"
+  },
+  "validation": {
+    "email": "ET_Please enter a valid email address",
+    "invalidPostalCode": "ET_Please enter a valid postal code",
+    "required": "ET_Please enter {{label}}",
+    "requiredTerms": "ET_Please accept the terms",
+    "tooLong": "ET_Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "ET_Please enter {{label}} that's more than {{min}} characters long"
+  },
+  "youthProfile": {
+    "approverEmail": "ET_Email",
+    "approverInfo": "ET_Approver information",
+    "approverName": "ET_Name",
+    "approverPhone": "ET_Phone",
+    "birthdate": "ET_Birthdate",
+    "homeLanguages": "ET_Language spoken at home",
+    "school": "ET_School"
+  },
+  "": "ET_"
+}

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -19,8 +19,8 @@
     "approveTermsText_link": "palvelun ehdot",
     "basicInfo": "Perustiedot",
     "birthDate": "Syntymäpäivä",
-    "explanationError": "Olet joko jo hyväksynyt nuoresi lähettämän hakemuksen tai palvelussamme on tapahtunut virhe.",
     "explanationCheckStatus": "Nuori voi tarkistaa hakemuksen tilan kirjautumalla Jässäriin. Pyydä häntä lähettämään vahvistusviesti uudestaan, mikäli hänen jäsenyyttään ei ole vielä hyväksytty.",
+    "explanationError": "Olet joko jo hyväksynyt nuoresi lähettämän hakemuksen tai palvelussamme on tapahtunut virhe.",
     "formExplanationText_1": "on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen. Jäsenyys on maksuton. Hyväksymällä hakemuksen,",
     "formExplanationText_2": "voi viettää aikaa nuorisotaloilla, osallistua harrastusryhmiin, kursseille ja leireille Nuorisotaloilla toimintaa ohjaavat koulutetut nuoriso-ohjaajat. Mikäli tiedoissa on virheitä, pyydä nuorta muuttamaan tiedot ja lähettämään sinulle uusi varmistusviesti.",
     "languagesAtHome": "Kotona puhutut kielet",
@@ -38,11 +38,11 @@
     "deviceTimeError": {
       "message": "Usko tai älä usko, mutta et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan."
     },
+    "errorMessage": "Tapahtui virhe. Yritä uudestaan",
+    "errorTitle": "Hupsista!",
     "permRequestDenied": {
       "message": "Sinun täytyy hyväksyä pyytämämme oikeudet Tunnistamossa käyttääksesi tätä palvelua. Ole hyvä ja yritä kirjautua uudelleen."
-    },
-    "errorTitle": "Hupsista!",
-    "errorMessage": "Tapahtui virhe. Yritä uudestaan"
+    }
   },
   "confirmSendingProfile": {
     "buttonText": "Lähetä uusi pyyntö huoltajalle",
@@ -54,8 +54,32 @@
   "edit": {
     "pageTitle": "Muokkaa omia tietoja"
   },
+  "emailApproval": {
+    "content": "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen. Jäsenyys on maksuton. Hyväksymällä hakemuksen, {{ youth_profile.profile.first_name }} voi käydä nuorisotalolla ja saa kivoja etuja. Mikäli tiedoissa on virheitä, pyydä nuorta muuttamaan tiedot ja lähettämään sinulle uusi varmistusviesti. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>",
+    "heading": "{{ youth_profile.profile.first_name }} on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen"
+  },
+  "emailApproved": {
+    "content": "Tervetuloa Helsingin kaupungin nuorisopalveluiden jäseneksi! {{ youth_profile.approver_first_name }} on hyväksynyt jäsenyytesi. Digitaalinen jäsenkorttisi löytyy täältä: <a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a><br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta <a href=\"http://jassari.munstadi.fi/\">http://jassari.munstadi.fi/</a>.<br /><br /><i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>",
+    "heading": "{{ youth_profile.approver_first_name }} on hyväksynyt nuorisopalveluiden jäsenyytesi"
+  },
+  "emailRenew": {
+    "content": "Tevehdys {{ youth_profile.profile.first_name }}! Nuorisopalveluiden jäsenyytesi on vanhentumassa. Uusi jäsenyytesi helposti täällä https://jassari.hel.fi/  Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/ <br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/<br /><br /> <i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>",
+    "heading": "{{ youth_profile.profile.first_name }} nuorisopalveluiden jäsenyytesi on vanhentumassa"
+  },
   "externalLink": {
     "description": "Aukeaa uuteen ikkunaan"
+  },
+  "fields": {
+    "city": "kaupunki",
+    "email": "sähköpostiosoite",
+    "firstName": "etunimi",
+    "lastName": "sukunimi",
+    "phoneNumber": "puhelinnumero",
+    "photoUsageApproved": "kuvauslupa",
+    "postalCode": "postinumero",
+    "schoolClass": "luokka",
+    "schoolName": "koulun nimi",
+    "streetAddress": "katuosoite"
   },
   "footer": {
     "accessibility": "Saavutettavuusseloste",
@@ -77,14 +101,14 @@
     "SWEDISH": "Ruotsi"
   },
   "language": {
-    "fi": "Suomi",
-    "sv": "Svenska",
+    "ar": "العربية",
     "en": "English",
+    "et": "eesti keel",
+    "fi": "Suomi",
     "fr": "français",
     "ru": "Русский язык",
-    "et": "eesti keel",
     "so": "af Soomaali",
-    "ar": "العربية"
+    "sv": "Svenska"
   },
   "loading": "Ladataan...",
   "login": {
@@ -93,10 +117,10 @@
     "helpText": "Jässärillä pääset mukaan nuorisopalveluiden toimintaan. Jäsenyys takaa sinulle kivaa tekemistä, voit hengailla nuorisotaloilla, osallistua harrastusryhmiin, kursseille ja leireille, hakea projektiavustusta tai vaikka tuottaa oman tapahtuman! Nuorisotaloilla toimintaa ohjaavat koulutetut nuoriso-ohjaajat.",
     "helpTextUnderAge": "Valitettavasti Jässärin hankkiminen digitaalisesti edellyttää vähintään 13 vuoden iän. Voit ladata jässärihakemuksen tästä. Täytä hakemus huoltajasi kanssa ja palauta se nuorisotilalle, niin saat oman jäsenkortin. ",
     "linkForMembersText": "Oletko jo jäsen? Kirjaudu sisään",
+    "pageTitle": "Nuorisotoimien jäsenkortti",
     "registrationForm": "http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_suomi.pdf",
     "registrationFormText": "Lataa hakemus",
     "return": "Palaa takaisin",
-    "pageTitle": "Nuorisotoimien jäsenkortti",
     "title": "Hanki Jässäri!"
   },
   "membershipDetails": {
@@ -112,39 +136,39 @@
   "membershipInformation": {
     "pageTitle": "Jäsenyyden tiedot",
     "renew": "Uusi jäsenyys",
-    "renewUnderage": "Lähetä uusimispyyntö huoltajalle",
     "renewSuccessMessage": "Jäsenyys uusittu onnistuneesti!",
     "renewSuccessMessageMinor": "Uusimispyyntö lähetetty onnistuneesti!",
     "renewSuccessTitle": "Onnistui",
+    "renewUnderage": "Lähetä uusimispyyntö huoltajalle",
     "showProfileInformation": "Näytä profiilin tiedot",
-    "title": "Jäsenkortin numero {{number}}",
-    "validUntil": "Voimassa {{date}} asti.",
     "status": {
+      "description": {
+        "expired": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.",
+        "pending": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}",
+        "renewable": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.",
+        "renewing": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}"
+      },
       "title": {
         "membershipExpired": "Jäsenyysaika on umpeutunut.",
-        "renewable": "Jäsenyysaika umpeutuu {{date}}.",
         "pending": "Jäsenyyden uusiminen odottaa huoltajan hyväksyntää.",
+        "renewable": "Jäsenyysaika umpeutuu {{date}}.",
         "renewing": "Jäsenyysaika umpeutuu {{date}}. Uusiminen odottaa huoltajan hyväksyntää."
-      },
-      "description": {
-        "renewable": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi.",
-        "pending": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}",
-        "renewing": "Pyyntö jäsenyyden uusimisesta on lähetetty osoitteeseen {{email}}",
-        "expired": "Lähetä jäsenyys uudelleen hyväksyttäväksi huoltajallesi."
       }
-    }
+    },
+    "title": "Jäsenkortin numero {{number}}",
+    "validUntil": "Voimassa {{date}} asti."
   },
   "meta": {
     "description": "Jässärillä pääset mukaan nuorisopalveluiden toimintaan. Jäsenyys takaa sinulle kivaa tekemistä, voit hengailla nuorisotaloilla, osallistua harrastusryhmiin, kursseille ja leireille, hakea projektiavustusta tai vaikka tuottaa oman tapahtuman! Nuorisotaloilla toimintaa ohjaavat koulutetut nuoriso-ohjaajat."
   },
   "nav": {
+    "helsinki": "Helsinki",
+    "menu": "Valikko",
     "menuButtonLabel": "Profiili valikko",
     "profile": "Helsinki-profiili",
     "signin": "Kirjaudu sisään",
     "signout": "Kirjaudu ulos",
-    "menu": "Valikko",
-    "skipToContent": "Siirry sivun pääsisältöön",
-    "helsinki": "Helsinki"
+    "skipToContent": "Siirry sivun pääsisältöön"
   },
   "notification": {
     "closeButtonText": "Sulje",
@@ -167,6 +191,9 @@
     "verifying": "Tarkistetaan profiilia..."
   },
   "registration": {
+    "addAddress": "Lisää toinen osoite",
+    "addGuardian": "Lisää toisen huoltajan yhteystiedot",
+    "addGuardianText": "Muihin ilmoittamiisi huoltajiin voidaan olla tarvittaessa yhteydessä nuorisojäsenyyteesi liittyvissä asioissa.",
     "addInfo": "Lisätiedot",
     "address": "Katuosoite",
     "ageRestriction": "Jässäri on tarkoitettu 8-29 -vuotiaille nuorille.",
@@ -201,16 +228,13 @@
     "postalCode": "Postinumero",
     "processInfoText": "Tietojen varmennuskysely lähetetään vanhemmalle ja kun tämä on tarkastanut ja hyväksynyt tiedot, jäsenyytesi astuu voimaan.",
     "profileLanguage": "Profiilin kieli",
+    "remove": "Poista",
     "save": "Tallenna tiedot",
     "schoolClass": "Luokka",
     "schoolName": "Koulu",
     "sendButton": "Tallenna tiedot ja lähetä varmistuspyyntö",
     "title": "Täytä tietosi",
-    "year": "Vuosi",
-    "addAddress": "Lisää toinen osoite",
-    "addGuardian": "Lisää toisen huoltajan yhteystiedot",
-    "addGuardianText": "Muihin ilmoittamiisi huoltajiin voidaan olla tarvittaessa yhteydessä nuorisojäsenyyteesi liittyvissä asioissa.",
-    "remove": "Poista"
+    "year": "Vuosi"
   },
   "registry": {
     "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Nuorisopalvelujen%20j%C3%A4senrekisteri.pdf"
@@ -239,8 +263,8 @@
   "validation": {
     "email": "Täytyä toimiva sähköpostiosoite",
     "invalidPostalCode": "Täytä oikea postinumero",
-    "requiredTerms": "Hyväksy ehdot",
     "required": "Täytä {{label}}",
+    "requiredTerms": "Hyväksy ehdot",
     "tooLong": "Täytä {{label}}, joka on korkeintaan {{max}} merkkiä",
     "tooShort": "Täytä {{label}}, joka on vähintään {{min}} merkkiä"
   },
@@ -252,29 +276,5 @@
     "birthdate": "Syntymäpäivä",
     "homeLanguages": "Kotona puhuttu kieli",
     "school": "Koulu"
-  },
-  "emailApproval": {
-    "heading": "{{ youth_profile.profile.first_name }} on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen",
-    "content": "Hei {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} on lähettänyt hyväksyttäväksesi Helsingin kaupungin nuorisopalvelujen jäsenyyshakemuksen. Jäsenyys on maksuton. Hyväksymällä hakemuksen, {{ youth_profile.profile.first_name }} voi käydä nuorisotalolla ja saa kivoja etuja. Mikäli tiedoissa on virheitä, pyydä nuorta muuttamaan tiedot ja lähettämään sinulle uusi varmistusviesti. Käy antamassa vahvistus Jässäri-palvelussa käyttäen tätä linkkiä: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
-  },
-  "emailApproved": {
-    "heading": "{{ youth_profile.approver_first_name }} on hyväksynyt nuorisopalveluiden jäsenyytesi",
-    "content": "Tervetuloa Helsingin kaupungin nuorisopalveluiden jäseneksi! {{ youth_profile.approver_first_name }} on hyväksynyt jäsenyytesi. Digitaalinen jäsenkorttisi löytyy täältä: <a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a><br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta <a href=\"http://jassari.munstadi.fi/\">http://jassari.munstadi.fi/</a>.<br /><br /><i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
-  },
-  "emailRenew": {
-    "heading": "{{ youth_profile.profile.first_name }} nuorisopalveluiden jäsenyytesi on vanhentumassa",
-    "content": "Tevehdys {{ youth_profile.profile.first_name }}! Nuorisopalveluiden jäsenyytesi on vanhentumassa. Uusi jäsenyytesi helposti täällä https://jassari.hel.fi/  Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/ <br /><br />Lisätietoa nuorisopalveluiden jäsenyydestä ja sen eduista voit lukea osoitteesta http://jassari.munstadi.fi/<br /><br /> <i>Tämä viesti on lähetetty järjestelmästä automaattisesti. Älä vastaa tähän viestiin, sillä vastauksia ei käsitellä.</i>"
-  },
-  "fields": {
-    "firstName": "etunimi",
-    "lastName": "sukunimi",
-    "streetAddress": "katuosoite",
-    "postalCode": "postinumero",
-    "city": "kaupunki",
-    "phoneNumber": "puhelinnumero",
-    "email": "sähköpostiosoite",
-    "schoolName": "koulun nimi",
-    "schoolClass": "luokka",
-    "photoUsageApproved": "kuvauslupa"
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,281 @@
+{
+  "appName": "FR_Jässäri",
+  "approval": {
+    "addGuardianText": "FR_Other added guardians may be contacted in matters concerning the child.",
+    "addInfo": "FR_Additional info",
+    "additionalAddresses": "FR_Additional addresses",
+    "address": "FR_Home address",
+    "approveButton": "FR_Approve membership",
+    "approvedLink": "FR_The link has expired",
+    "approvedMessage": "FR_Thank you for confirming youth service membership.",
+    "approvedTitle": "FR_Jässäri membership approved!",
+    "approverAcceptance": "FR_Permissions to be approved",
+    "approverEmail": "FR_Email",
+    "approverFirstName": "FR_Firstname",
+    "approverInfo": "FR_Approver info",
+    "approverInfoText": "FR_Guardian may be contacted concerning the child.",
+    "approverLastName": "FR_Lastname",
+    "approveTerms": "FR_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "approveTermsText_link": "FR_service terms",
+    "basicInfo": "FR_Basic info",
+    "birthDate": "FR_Birthdate",
+    "explanationCheckStatus": "FR_The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "FR_You have either already approved the application submitted by your youth or an error has occurred in our service.",
+    "formExplanationText_1": "FR_has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
+    "formExplanationText_2": "FR_may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
+    "languagesAtHome": "FR_Languages at home",
+    "name": "FR_Name",
+    "phone": "FR_Phone",
+    "photoUsageApproved": "FR_Photo usage approval",
+    "photoUsageApprovedNo": "FR_No",
+    "photoUsageApprovedText": "FR_The young person may be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "FR_Yes",
+    "profile": "FR_Profile",
+    "schoolInfo": "FR_School and class",
+    "title": "FR_Please approve membership"
+  },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "FR_Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "errorMessage": "FR_An error occured while logging in. Please try again",
+    "errorTitle": "FR_Oops!",
+    "permRequestDenied": {
+      "message": "FR_You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    }
+  },
+  "confirmSendingProfile": {
+    "buttonText": "FR_Send a new request to the guardian",
+    "helpText": "FR_Your membership application has been sent to",
+    "linkToShowSentData": "FR_Display your application",
+    "sendAgainHelpText": "FR_Approval email has been re-sent to",
+    "title": "FR_The application has been sent to your guardian for approval!"
+  },
+  "edit": {
+    "pageTitle": "FR_Edit own information"
+  },
+  "emailApproval": {
+    "content": "FR_Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "FR_{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "FR_Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "FR_{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "FR_Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "FR_{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
+  "externalLink": {
+    "description": "FR_Opens in a new window"
+  },
+  "fields": {
+    "city": "FR_a city",
+    "email": "FR_an email",
+    "firstName": "FR_a first name",
+    "lastName": "FR_a last name",
+    "phoneNumber": "FR_a phone number",
+    "photoUsageApproved": "FR_photo usage approval",
+    "postalCode": "FR_a postal code",
+    "schoolClass": "FR_a school class",
+    "schoolName": "FR_a school name",
+    "streetAddress": "FR_a street address"
+  },
+  "footer": {
+    "accessibility": "FR_Accessibility document",
+    "copyright": "FR_City of Helsinki",
+    "feedback": "FR_Give feedback",
+    "feedbackLink": "FR_https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/en/feedback/feedback/",
+    "privacy": "FR_Privacy policy",
+    "reserveRights": "FR_All rights reserved",
+    "terms": "FR_Terms of Service"
+  },
+  "helsinkiLogo": "FR_Helsinki logo",
+  "LANGUAGE_OPTIONS": {
+    "ARABIC": "FR_Arabic",
+    "ENGLISH": "FR_English",
+    "ESTONIAN": "FR_Estonian",
+    "FINNISH": "FR_Finnish",
+    "RUSSIAN": "FR_Russian",
+    "SOMALI": "FR_Somali",
+    "SWEDISH": "FR_Swedish"
+  },
+  "language": {
+    "ar": "FR_العربية",
+    "en": "FR_English",
+    "et": "FR_eesti keel",
+    "fi": "FR_Suomi",
+    "fr": "FR_français",
+    "ru": "FR_Русский язык",
+    "so": "FR_af Soomaali",
+    "sv": "FR_Svenska"
+  },
+  "loading": "FR_Loading...",
+  "login": {
+    "buttonText": "FR_Get membership",
+    "findNearestService": "FR_Find the nearest youth centre on the service map",
+    "helpText": "FR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "helpTextUnderAge": "FR_Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
+    "linkForMembersText": "FR_Do you have membership? Log in",
+    "pageTitle": "FR_Youth membership card",
+    "registrationForm": "FR_http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
+    "registrationFormText": "FR_Download application form",
+    "return": "FR_Go back",
+    "title": "FR_Get your Jässäri!"
+  },
+  "membershipDetails": {
+    "additionalInformation": "FR_Additional information",
+    "edit": "FR_Edit information",
+    "photoUsageExplanation": "FR_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "profileInformation": "FR_Basic information",
+    "requiredPermissionsFromParent": "FR_Required permissions from parent",
+    "returnToFront": "FR_Return to frontpage",
+    "text": "FR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "title": "FR_Own information"
+  },
+  "membershipInformation": {
+    "pageTitle": "FR_Membership information",
+    "renew": "FR_Renew membership",
+    "renewSuccessMessage": "FR_Membership renewed successfully!",
+    "renewSuccessMessageMinor": "FR_Renewal request sent successfully!",
+    "renewSuccessTitle": "FR_Success",
+    "renewUnderage": "FR_Send a renewal request to the guardian",
+    "showProfileInformation": "FR_Show profile information",
+    "status": {
+      "description": {
+        "expired": "FR_Resubmit your membership to your guardian for approval.",
+        "pending": "FR_Your renewal request has been sent to {{email}}",
+        "renewable": "FR_Resubmit your membership to your guardian for approval.",
+        "renewing": "FR_Your renewal request has been sent to {{email}}"
+      },
+      "title": {
+        "membershipExpired": "FR_Membership has expired.",
+        "pending": "FR_Renewal of membership is awaiting for guardian approval.",
+        "renewable": "FR_Membership expires on {{date}}.",
+        "renewing": "FR_Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      }
+    },
+    "title": "FR_Membership card number {{number}}",
+    "validUntil": "FR_Valid until {{date}}"
+  },
+  "meta": {
+    "description": "FR_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
+  },
+  "nav": {
+    "helsinki": "FR_Helsinki",
+    "menu": "FR_Menu",
+    "menuButtonLabel": "FR_Profile menu",
+    "profile": "FR_Helsinki Profile",
+    "signin": "FR_Log in",
+    "signout": "FR_Log out",
+    "skipToContent": "FR_Skip to main content"
+  },
+  "notification": {
+    "closeButtonText": "FR_Close",
+    "defaultErrorText": "FR_Something went wrong. Try again after a while.",
+    "defaultErrorTitle": "FR_Error"
+  },
+  "oidc": {
+    "authenticating": "FR_Authenticating..."
+  },
+  "privacyPolicy": {
+    "descriptionLink": "FR_https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "FR_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
+  },
+  "profile": {
+    "address": "FR_Address",
+    "email": "FR_Email",
+    "loading": "FR_Loading profile...",
+    "name": "FR_Name",
+    "phone": "FR_Phone",
+    "verifying": "FR_Checking profile..."
+  },
+  "registration": {
+    "addAddress": "FR_Add another address",
+    "addGuardian": "FR_Add another guardian's information ",
+    "addGuardianText": "FR_If necessary other guardians may be contacted in matters relating to your youth membership.",
+    "addInfo": "FR_Additional info",
+    "address": "FR_Street",
+    "ageRestriction": "FR_Jässäri is only for youths between 8-29 years.",
+    "approver": "FR_Approver",
+    "approverInfoOver18Text": "FR_For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
+    "approverInfoText": "FR_A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
+    "approveTerms": "FR_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "basicInfo": "FR_Basic info",
+    "birthdayHelper": "FR_Birthdate (dd.mm.yyyy) *",
+    "birthdayInvalid": "FR_The birthday should be dd.mm.yyyy.",
+    "cancel": "FR_Cancel",
+    "childBirthDay": "FR_Birthdate",
+    "childBirthMonth": "FR_Birthmonth",
+    "childBirthYear": "FR_Birthyear",
+    "city": "FR_City",
+    "confirmSend": "FR_Accept the terms and send the application",
+    "country": "FR_Country",
+    "date": "FR_Date",
+    "dateInvalid": "FR_Invalid date",
+    "email": "FR_Email",
+    "firstName": "FR_First name",
+    "languageAtHome": "FR_Language at home",
+    "lastName": "FR_Last name",
+    "membershipInfoText": "FR_Membership is free and does not require anything of you, but you do need a membership to be able to participate in activities at Youth Centres. We will not disclose your information to third parties. You have the right to check and remove the information we have stored concerning you. Please remember that intoxicants are not allowed at Youth Centre activities. ",
+    "month": "FR_Month",
+    "pageTitle": "FR_Create profile",
+    "phoneNumber": "FR_Phone",
+    "photoUsageApproved": "FR_Photo usage approved",
+    "photoUsageApprovedNo": "FR_No",
+    "photoUsageApprovedText": "FR_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "FR_Yes",
+    "postalCode": "FR_Postal code",
+    "processInfoText": "FR_A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
+    "profileLanguage": "FR_Profile language",
+    "remove": "FR_Delete",
+    "save": "FR_Save information",
+    "schoolClass": "FR_School class",
+    "schoolName": "FR_School name",
+    "sendButton": "FR_Save and send approval request",
+    "title": "FR_Please fill in your information",
+    "year": "FR_Year"
+  },
+  "registry": {
+    "descriptionLink": "FR_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
+  },
+  "sanityCheck": "FR_youth-profile.en",
+  "tos": {
+    "message1": "FR_Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "message2": "FR_",
+    "message3": "FR_",
+    "message4": "FR_",
+    "message5": "FR_",
+    "message6": "FR_",
+    "message7": "FR_",
+    "message8": "FR_",
+    "title": "FR_Terms of Service",
+    "title1": "FR_1. Scope of application",
+    "title2": "FR_2. Create and disable a profile",
+    "title3": "FR_3. Using a profile",
+    "title4": "FR_4. Availability of the service",
+    "title5": "FR_5. Personal information",
+    "title6": "FR_6. Rights",
+    "title7": "FR_7. Limitation of Liability",
+    "title8": "FR_8. Other terms and conditions",
+    "updated": "FR_Updated 20.1.2020"
+  },
+  "validation": {
+    "email": "FR_Please enter a valid email address",
+    "invalidPostalCode": "FR_Please enter a valid postal code",
+    "required": "FR_Please enter {{label}}",
+    "requiredTerms": "FR_Please accept the terms",
+    "tooLong": "FR_Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "FR_Please enter {{label}} that's more than {{min}} characters long"
+  },
+  "youthProfile": {
+    "approverEmail": "FR_Email",
+    "approverInfo": "FR_Approver information",
+    "approverName": "FR_Name",
+    "approverPhone": "FR_Phone",
+    "birthdate": "FR_Birthdate",
+    "homeLanguages": "FR_Language spoken at home",
+    "school": "FR_School"
+  },
+  "": "FR_"
+}

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -1,0 +1,281 @@
+{
+  "appName": "RU_Jässäri",
+  "approval": {
+    "addGuardianText": "RU_Other added guardians may be contacted in matters concerning the child.",
+    "addInfo": "RU_Additional info",
+    "additionalAddresses": "RU_Additional addresses",
+    "address": "RU_Home address",
+    "approveButton": "RU_Approve membership",
+    "approvedLink": "RU_The link has expired",
+    "approvedMessage": "RU_Thank you for confirming youth service membership.",
+    "approvedTitle": "RU_Jässäri membership approved!",
+    "approverAcceptance": "RU_Permissions to be approved",
+    "approverEmail": "RU_Email",
+    "approverFirstName": "RU_Firstname",
+    "approverInfo": "RU_Approver info",
+    "approverInfoText": "RU_Guardian may be contacted concerning the child.",
+    "approverLastName": "RU_Lastname",
+    "approveTerms": "RU_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "approveTermsText_link": "RU_service terms",
+    "basicInfo": "RU_Basic info",
+    "birthDate": "RU_Birthdate",
+    "explanationCheckStatus": "RU_The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "RU_You have either already approved the application submitted by your youth or an error has occurred in our service.",
+    "formExplanationText_1": "RU_has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
+    "formExplanationText_2": "RU_may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
+    "languagesAtHome": "RU_Languages at home",
+    "name": "RU_Name",
+    "phone": "RU_Phone",
+    "photoUsageApproved": "RU_Photo usage approval",
+    "photoUsageApprovedNo": "RU_No",
+    "photoUsageApprovedText": "RU_The young person may be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "RU_Yes",
+    "profile": "RU_Profile",
+    "schoolInfo": "RU_School and class",
+    "title": "RU_Please approve membership"
+  },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "RU_Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "errorMessage": "RU_An error occured while logging in. Please try again",
+    "errorTitle": "RU_Oops!",
+    "permRequestDenied": {
+      "message": "RU_You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    }
+  },
+  "confirmSendingProfile": {
+    "buttonText": "RU_Send a new request to the guardian",
+    "helpText": "RU_Your membership application has been sent to",
+    "linkToShowSentData": "RU_Display your application",
+    "sendAgainHelpText": "RU_Approval email has been re-sent to",
+    "title": "RU_The application has been sent to your guardian for approval!"
+  },
+  "edit": {
+    "pageTitle": "RU_Edit own information"
+  },
+  "emailApproval": {
+    "content": "RU_Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "RU_{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "RU_Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "RU_{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "RU_Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "RU_{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
+  "externalLink": {
+    "description": "RU_Opens in a new window"
+  },
+  "fields": {
+    "city": "RU_a city",
+    "email": "RU_an email",
+    "firstName": "RU_a first name",
+    "lastName": "RU_a last name",
+    "phoneNumber": "RU_a phone number",
+    "photoUsageApproved": "RU_photo usage approval",
+    "postalCode": "RU_a postal code",
+    "schoolClass": "RU_a school class",
+    "schoolName": "RU_a school name",
+    "streetAddress": "RU_a street address"
+  },
+  "footer": {
+    "accessibility": "RU_Accessibility document",
+    "copyright": "RU_City of Helsinki",
+    "feedback": "RU_Give feedback",
+    "feedbackLink": "RU_https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/en/feedback/feedback/",
+    "privacy": "RU_Privacy policy",
+    "reserveRights": "RU_All rights reserved",
+    "terms": "RU_Terms of Service"
+  },
+  "helsinkiLogo": "RU_Helsinki logo",
+  "LANGUAGE_OPTIONS": {
+    "ARABIC": "RU_Arabic",
+    "ENGLISH": "RU_English",
+    "ESTONIAN": "RU_Estonian",
+    "FINNISH": "RU_Finnish",
+    "RUSSIAN": "RU_Russian",
+    "SOMALI": "RU_Somali",
+    "SWEDISH": "RU_Swedish"
+  },
+  "language": {
+    "ar": "RU_العربية",
+    "en": "RU_English",
+    "et": "RU_eesti keel",
+    "fi": "RU_Suomi",
+    "fr": "RU_français",
+    "ru": "RU_Русский язык",
+    "so": "RU_af Soomaali",
+    "sv": "RU_Svenska"
+  },
+  "loading": "RU_Loading...",
+  "login": {
+    "buttonText": "RU_Get membership",
+    "findNearestService": "RU_Find the nearest youth centre on the service map",
+    "helpText": "RU_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "helpTextUnderAge": "RU_Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
+    "linkForMembersText": "RU_Do you have membership? Log in",
+    "pageTitle": "RU_Youth membership card",
+    "registrationForm": "RU_http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
+    "registrationFormText": "RU_Download application form",
+    "return": "RU_Go back",
+    "title": "RU_Get your Jässäri!"
+  },
+  "membershipDetails": {
+    "additionalInformation": "RU_Additional information",
+    "edit": "RU_Edit information",
+    "photoUsageExplanation": "RU_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "profileInformation": "RU_Basic information",
+    "requiredPermissionsFromParent": "RU_Required permissions from parent",
+    "returnToFront": "RU_Return to frontpage",
+    "text": "RU_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "title": "RU_Own information"
+  },
+  "membershipInformation": {
+    "pageTitle": "RU_Membership information",
+    "renew": "RU_Renew membership",
+    "renewSuccessMessage": "RU_Membership renewed successfully!",
+    "renewSuccessMessageMinor": "RU_Renewal request sent successfully!",
+    "renewSuccessTitle": "RU_Success",
+    "renewUnderage": "RU_Send a renewal request to the guardian",
+    "showProfileInformation": "RU_Show profile information",
+    "status": {
+      "description": {
+        "expired": "RU_Resubmit your membership to your guardian for approval.",
+        "pending": "RU_Your renewal request has been sent to {{email}}",
+        "renewable": "RU_Resubmit your membership to your guardian for approval.",
+        "renewing": "RU_Your renewal request has been sent to {{email}}"
+      },
+      "title": {
+        "membershipExpired": "RU_Membership has expired.",
+        "pending": "RU_Renewal of membership is awaiting for guardian approval.",
+        "renewable": "RU_Membership expires on {{date}}.",
+        "renewing": "RU_Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      }
+    },
+    "title": "RU_Membership card number {{number}}",
+    "validUntil": "RU_Valid until {{date}}"
+  },
+  "meta": {
+    "description": "RU_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
+  },
+  "nav": {
+    "helsinki": "RU_Helsinki",
+    "menu": "RU_Menu",
+    "menuButtonLabel": "RU_Profile menu",
+    "profile": "RU_Helsinki Profile",
+    "signin": "RU_Log in",
+    "signout": "RU_Log out",
+    "skipToContent": "RU_Skip to main content"
+  },
+  "notification": {
+    "closeButtonText": "RU_Close",
+    "defaultErrorText": "RU_Something went wrong. Try again after a while.",
+    "defaultErrorTitle": "RU_Error"
+  },
+  "oidc": {
+    "authenticating": "RU_Authenticating..."
+  },
+  "privacyPolicy": {
+    "descriptionLink": "RU_https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "RU_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
+  },
+  "profile": {
+    "address": "RU_Address",
+    "email": "RU_Email",
+    "loading": "RU_Loading profile...",
+    "name": "RU_Name",
+    "phone": "RU_Phone",
+    "verifying": "RU_Checking profile..."
+  },
+  "registration": {
+    "addAddress": "RU_Add another address",
+    "addGuardian": "RU_Add another guardian's information ",
+    "addGuardianText": "RU_If necessary other guardians may be contacted in matters relating to your youth membership.",
+    "addInfo": "RU_Additional info",
+    "address": "RU_Street",
+    "ageRestriction": "RU_Jässäri is only for youths between 8-29 years.",
+    "approver": "RU_Approver",
+    "approverInfoOver18Text": "RU_For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
+    "approverInfoText": "RU_A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
+    "approveTerms": "RU_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "basicInfo": "RU_Basic info",
+    "birthdayHelper": "RU_Birthdate (dd.mm.yyyy) *",
+    "birthdayInvalid": "RU_The birthday should be dd.mm.yyyy.",
+    "cancel": "RU_Cancel",
+    "childBirthDay": "RU_Birthdate",
+    "childBirthMonth": "RU_Birthmonth",
+    "childBirthYear": "RU_Birthyear",
+    "city": "RU_City",
+    "confirmSend": "RU_Accept the terms and send the application",
+    "country": "RU_Country",
+    "date": "RU_Date",
+    "dateInvalid": "RU_Invalid date",
+    "email": "RU_Email",
+    "firstName": "RU_First name",
+    "languageAtHome": "RU_Language at home",
+    "lastName": "RU_Last name",
+    "membershipInfoText": "RU_Membership is free and does not require anything of you, but you do need a membership to be able to participate in activities at Youth Centres. We will not disclose your information to third parties. You have the right to check and remove the information we have stored concerning you. Please remember that intoxicants are not allowed at Youth Centre activities. ",
+    "month": "RU_Month",
+    "pageTitle": "RU_Create profile",
+    "phoneNumber": "RU_Phone",
+    "photoUsageApproved": "RU_Photo usage approved",
+    "photoUsageApprovedNo": "RU_No",
+    "photoUsageApprovedText": "RU_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "RU_Yes",
+    "postalCode": "RU_Postal code",
+    "processInfoText": "RU_A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
+    "profileLanguage": "RU_Profile language",
+    "remove": "RU_Delete",
+    "save": "RU_Save information",
+    "schoolClass": "RU_School class",
+    "schoolName": "RU_School name",
+    "sendButton": "RU_Save and send approval request",
+    "title": "RU_Please fill in your information",
+    "year": "RU_Year"
+  },
+  "registry": {
+    "descriptionLink": "RU_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
+  },
+  "sanityCheck": "RU_youth-profile.en",
+  "tos": {
+    "message1": "RU_Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "message2": "RU_",
+    "message3": "RU_",
+    "message4": "RU_",
+    "message5": "RU_",
+    "message6": "RU_",
+    "message7": "RU_",
+    "message8": "RU_",
+    "title": "RU_Terms of Service",
+    "title1": "RU_1. Scope of application",
+    "title2": "RU_2. Create and disable a profile",
+    "title3": "RU_3. Using a profile",
+    "title4": "RU_4. Availability of the service",
+    "title5": "RU_5. Personal information",
+    "title6": "RU_6. Rights",
+    "title7": "RU_7. Limitation of Liability",
+    "title8": "RU_8. Other terms and conditions",
+    "updated": "RU_Updated 20.1.2020"
+  },
+  "validation": {
+    "email": "RU_Please enter a valid email address",
+    "invalidPostalCode": "RU_Please enter a valid postal code",
+    "required": "RU_Please enter {{label}}",
+    "requiredTerms": "RU_Please accept the terms",
+    "tooLong": "RU_Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "RU_Please enter {{label}} that's more than {{min}} characters long"
+  },
+  "youthProfile": {
+    "approverEmail": "RU_Email",
+    "approverInfo": "RU_Approver information",
+    "approverName": "RU_Name",
+    "approverPhone": "RU_Phone",
+    "birthdate": "RU_Birthdate",
+    "homeLanguages": "RU_Language spoken at home",
+    "school": "RU_School"
+  },
+  "": "RU_"
+}

--- a/src/i18n/so.json
+++ b/src/i18n/so.json
@@ -1,0 +1,281 @@
+{
+  "appName": "SO_Jässäri",
+  "approval": {
+    "addGuardianText": "SO_Other added guardians may be contacted in matters concerning the child.",
+    "addInfo": "SO_Additional info",
+    "additionalAddresses": "SO_Additional addresses",
+    "address": "SO_Home address",
+    "approveButton": "SO_Approve membership",
+    "approvedLink": "SO_The link has expired",
+    "approvedMessage": "SO_Thank you for confirming youth service membership.",
+    "approvedTitle": "SO_Jässäri membership approved!",
+    "approverAcceptance": "SO_Permissions to be approved",
+    "approverEmail": "SO_Email",
+    "approverFirstName": "SO_Firstname",
+    "approverInfo": "SO_Approver info",
+    "approverInfoText": "SO_Guardian may be contacted concerning the child.",
+    "approverLastName": "SO_Lastname",
+    "approveTerms": "SO_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "approveTermsText_link": "SO_service terms",
+    "basicInfo": "SO_Basic info",
+    "birthDate": "SO_Birthdate",
+    "explanationCheckStatus": "SO_The youth can check their application's status by logging in to Jässäri. Ask them to resend the confirmation message if their membership has not yet been approved.",
+    "explanationError": "SO_You have either already approved the application submitted by your youth or an error has occurred in our service.",
+    "formExplanationText_1": "SO_has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application,",
+    "formExplanationText_2": "SO_may visit Youth Centres and participate in fun activities. The activities at Youth Centres are instructed by trained youth workers.  If the information is incorrect, ask the young person to change it and send a new verification message to you.",
+    "languagesAtHome": "SO_Languages at home",
+    "name": "SO_Name",
+    "phone": "SO_Phone",
+    "photoUsageApproved": "SO_Photo usage approval",
+    "photoUsageApprovedNo": "SO_No",
+    "photoUsageApprovedText": "SO_The young person may be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "SO_Yes",
+    "profile": "SO_Profile",
+    "schoolInfo": "SO_School and class",
+    "title": "SO_Please approve membership"
+  },
+  "authentication": {
+    "deviceTimeError": {
+      "message": "SO_Believe it or not, but we can’t allow you to log in because the clock on your device is off by more than five minutes. Please set the time and try again."
+    },
+    "errorMessage": "SO_An error occured while logging in. Please try again",
+    "errorTitle": "SO_Oops!",
+    "permRequestDenied": {
+      "message": "SO_You need to approve our request to access your Tunnistamo profile in order to use this service. Please try logging in again."
+    }
+  },
+  "confirmSendingProfile": {
+    "buttonText": "SO_Send a new request to the guardian",
+    "helpText": "SO_Your membership application has been sent to",
+    "linkToShowSentData": "SO_Display your application",
+    "sendAgainHelpText": "SO_Approval email has been re-sent to",
+    "title": "SO_The application has been sent to your guardian for approval!"
+  },
+  "edit": {
+    "pageTitle": "SO_Edit own information"
+  },
+  "emailApproval": {
+    "content": "SO_Hi {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval. The membership is free of charge. If you approve the application, {{ youth_profile.profile.first_name }} may visit Youth Centres and enjoy fun benefits. If the information is incorrect, ask the youth to change it and send a new approval request to you. You can give your approval using the Jässäri service via this link: <br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /><i> This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "SO_{{ youth_profile.profile.first_name }} has sent a membership application for the City of Helsinki’s Youth Services for your approval."
+  },
+  "emailApproved": {
+    "content": "SO_Welcome to the Youth Services of the City of Helsinki! {{ youth_profile.approver_first_name }} has approved your membership. Your digital membersip card can be found here: <br /><br /><a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a> <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "SO_{{ youth_profile.approver_first_name }} has approved your Youth Services membership"
+  },
+  "emailRenew": {
+    "content": "SO_Hi {{ youth_profile.profile.first_name }}! Your Youth Services membership is about to expire You can easily renew your membership here https://jassari.hel.fi/ <br /><br />For more information on the Youth Services membership and its perks, please visit <a href=\"http://jassari.munstadi.fi/en/\">http://jassari.munstadi.fi/en/</a><br /><br /><i>This message was sent automatically from our system. Please do not reply to this message as the replies will not be processed.</i>",
+    "heading": "SO_{{ youth_profile.profile.first_name }} your Youth Services membership is about to expire"
+  },
+  "externalLink": {
+    "description": "SO_Opens in a new window"
+  },
+  "fields": {
+    "city": "SO_a city",
+    "email": "SO_an email",
+    "firstName": "SO_a first name",
+    "lastName": "SO_a last name",
+    "phoneNumber": "SO_a phone number",
+    "photoUsageApproved": "SO_photo usage approval",
+    "postalCode": "SO_a postal code",
+    "schoolClass": "SO_a school class",
+    "schoolName": "SO_a school name",
+    "streetAddress": "SO_a street address"
+  },
+  "footer": {
+    "accessibility": "SO_Accessibility document",
+    "copyright": "SO_City of Helsinki",
+    "feedback": "SO_Give feedback",
+    "feedbackLink": "SO_https://www.hel.fi/kulttuurin-ja-vapaa-ajan-toimiala/en/feedback/feedback/",
+    "privacy": "SO_Privacy policy",
+    "reserveRights": "SO_All rights reserved",
+    "terms": "SO_Terms of Service"
+  },
+  "helsinkiLogo": "SO_Helsinki logo",
+  "LANGUAGE_OPTIONS": {
+    "ARABIC": "SO_Arabic",
+    "ENGLISH": "SO_English",
+    "ESTONIAN": "SO_Estonian",
+    "FINNISH": "SO_Finnish",
+    "RUSSIAN": "SO_Russian",
+    "SOMALI": "SO_Somali",
+    "SWEDISH": "SO_Swedish"
+  },
+  "language": {
+    "ar": "SO_العربية",
+    "en": "SO_English",
+    "et": "SO_eesti keel",
+    "fi": "SO_Suomi",
+    "fr": "SO_français",
+    "ru": "SO_Русский язык",
+    "so": "SO_af Soomaali",
+    "sv": "SO_Svenska"
+  },
+  "loading": "SO_Loading...",
+  "login": {
+    "buttonText": "SO_Get membership",
+    "findNearestService": "SO_Find the nearest youth centre on the service map",
+    "helpText": "SO_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "helpTextUnderAge": "SO_Unfortunately, you need to be at least 13 years old to get a digital Jässäri. You can download an application form from here.  Fill in the application form with your guardian and take it back to the Youth Centre to get your own membership card. ",
+    "linkForMembersText": "SO_Do you have membership? Log in",
+    "pageTitle": "SO_Youth membership card",
+    "registrationForm": "SO_http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_englanti-1.pdf",
+    "registrationFormText": "SO_Download application form",
+    "return": "SO_Go back",
+    "title": "SO_Get your Jässäri!"
+  },
+  "membershipDetails": {
+    "additionalInformation": "SO_Additional information",
+    "edit": "SO_Edit information",
+    "photoUsageExplanation": "SO_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "profileInformation": "SO_Basic information",
+    "requiredPermissionsFromParent": "SO_Required permissions from parent",
+    "returnToFront": "SO_Return to frontpage",
+    "text": "SO_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers.",
+    "title": "SO_Own information"
+  },
+  "membershipInformation": {
+    "pageTitle": "SO_Membership information",
+    "renew": "SO_Renew membership",
+    "renewSuccessMessage": "SO_Membership renewed successfully!",
+    "renewSuccessMessageMinor": "SO_Renewal request sent successfully!",
+    "renewSuccessTitle": "SO_Success",
+    "renewUnderage": "SO_Send a renewal request to the guardian",
+    "showProfileInformation": "SO_Show profile information",
+    "status": {
+      "description": {
+        "expired": "SO_Resubmit your membership to your guardian for approval.",
+        "pending": "SO_Your renewal request has been sent to {{email}}",
+        "renewable": "SO_Resubmit your membership to your guardian for approval.",
+        "renewing": "SO_Your renewal request has been sent to {{email}}"
+      },
+      "title": {
+        "membershipExpired": "SO_Membership has expired.",
+        "pending": "SO_Renewal of membership is awaiting for guardian approval.",
+        "renewable": "SO_Membership expires on {{date}}.",
+        "renewing": "SO_Membership expires on {{date}}. Renewal is awaiting guardian approval."
+      }
+    },
+    "title": "SO_Membership card number {{number}}",
+    "validUntil": "SO_Valid until {{date}}"
+  },
+  "meta": {
+    "description": "SO_Jässäri gives you access to the Youth Services’ activities. With Jässäri membership, you can participate in fun activities, hang out at Youth Centres, join hobby groups, courses and camps, apply for project subsidies or even produce your own event! The activities at Youth Centres are instructed by trained youth workers."
+  },
+  "nav": {
+    "helsinki": "SO_Helsinki",
+    "menu": "SO_Menu",
+    "menuButtonLabel": "SO_Profile menu",
+    "profile": "SO_Helsinki Profile",
+    "signin": "SO_Log in",
+    "signout": "SO_Log out",
+    "skipToContent": "SO_Skip to main content"
+  },
+  "notification": {
+    "closeButtonText": "SO_Close",
+    "defaultErrorText": "SO_Something went wrong. Try again after a while.",
+    "defaultErrorTitle": "SO_Error"
+  },
+  "oidc": {
+    "authenticating": "SO_Authenticating..."
+  },
+  "privacyPolicy": {
+    "descriptionLink": "SO_https://www.hel.fi/helsinki/en/administration/information/data-protection",
+    "helsinkiProfileLink": "SO_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf"
+  },
+  "profile": {
+    "address": "SO_Address",
+    "email": "SO_Email",
+    "loading": "SO_Loading profile...",
+    "name": "SO_Name",
+    "phone": "SO_Phone",
+    "verifying": "SO_Checking profile..."
+  },
+  "registration": {
+    "addAddress": "SO_Add another address",
+    "addGuardian": "SO_Add another guardian's information ",
+    "addGuardianText": "SO_If necessary other guardians may be contacted in matters relating to your youth membership.",
+    "addInfo": "SO_Additional info",
+    "address": "SO_Street",
+    "ageRestriction": "SO_Jässäri is only for youths between 8-29 years.",
+    "approver": "SO_Approver",
+    "approverInfoOver18Text": "SO_For members over 18, we don't require providing custodian contact information. If for any reason you wish us to be able to contact them, you can add the information here.",
+    "approverInfoText": "SO_A confirmation request concerning your membership will be sent to this address, and your guardian must verify the information and approve your membership.",
+    "approveTerms": "SO_I have read <0>the privacy policy of this service</0>, <1>the privacy policy of Helsinki profile</1> and <2>the city's data protection principles</2>. I can be contacted using the information I have given.",
+    "basicInfo": "SO_Basic info",
+    "birthdayHelper": "SO_Birthdate (dd.mm.yyyy) *",
+    "birthdayInvalid": "SO_The birthday should be dd.mm.yyyy.",
+    "cancel": "SO_Cancel",
+    "childBirthDay": "SO_Birthdate",
+    "childBirthMonth": "SO_Birthmonth",
+    "childBirthYear": "SO_Birthyear",
+    "city": "SO_City",
+    "confirmSend": "SO_Accept the terms and send the application",
+    "country": "SO_Country",
+    "date": "SO_Date",
+    "dateInvalid": "SO_Invalid date",
+    "email": "SO_Email",
+    "firstName": "SO_First name",
+    "languageAtHome": "SO_Language at home",
+    "lastName": "SO_Last name",
+    "membershipInfoText": "SO_Membership is free and does not require anything of you, but you do need a membership to be able to participate in activities at Youth Centres. We will not disclose your information to third parties. You have the right to check and remove the information we have stored concerning you. Please remember that intoxicants are not allowed at Youth Centre activities. ",
+    "month": "SO_Month",
+    "pageTitle": "SO_Create profile",
+    "phoneNumber": "SO_Phone",
+    "photoUsageApproved": "SO_Photo usage approved",
+    "photoUsageApprovedNo": "SO_No",
+    "photoUsageApprovedText": "SO_I can be photographed and the photos may be used in the printed and electronic communications and marketing of the City of Helsinki. The City will not pay compensation for photographing and using the photos. The right to use the photos will remain in effect until further notice, and it concerns all communications and marketing communications of the City of Helsinki.",
+    "photoUsageApprovedYes": "SO_Yes",
+    "postalCode": "SO_Postal code",
+    "processInfoText": "SO_A data verification request will be sent to the parent and once they have reviewed and approved the information, your membership will take effect.",
+    "profileLanguage": "SO_Profile language",
+    "remove": "SO_Delete",
+    "save": "SO_Save information",
+    "schoolClass": "SO_School class",
+    "schoolName": "SO_School name",
+    "sendButton": "SO_Save and send approval request",
+    "title": "SO_Please fill in your information",
+    "year": "SO_Year"
+  },
+  "registry": {
+    "descriptionLink": "SO_https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Youth%20services%20membership%20data%20file.pdf"
+  },
+  "sanityCheck": "SO_youth-profile.en",
+  "tos": {
+    "message1": "SO_Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "message2": "SO_",
+    "message3": "SO_",
+    "message4": "SO_",
+    "message5": "SO_",
+    "message6": "SO_",
+    "message7": "SO_",
+    "message8": "SO_",
+    "title": "SO_Terms of Service",
+    "title1": "SO_1. Scope of application",
+    "title2": "SO_2. Create and disable a profile",
+    "title3": "SO_3. Using a profile",
+    "title4": "SO_4. Availability of the service",
+    "title5": "SO_5. Personal information",
+    "title6": "SO_6. Rights",
+    "title7": "SO_7. Limitation of Liability",
+    "title8": "SO_8. Other terms and conditions",
+    "updated": "SO_Updated 20.1.2020"
+  },
+  "validation": {
+    "email": "SO_Please enter a valid email address",
+    "invalidPostalCode": "SO_Please enter a valid postal code",
+    "required": "SO_Please enter {{label}}",
+    "requiredTerms": "SO_Please accept the terms",
+    "tooLong": "SO_Please enter {{label}} that's less than {{max}} characters long",
+    "tooShort": "SO_Please enter {{label}} that's more than {{min}} characters long"
+  },
+  "youthProfile": {
+    "approverEmail": "SO_Email",
+    "approverInfo": "SO_Approver information",
+    "approverName": "SO_Name",
+    "approverPhone": "SO_Phone",
+    "birthdate": "SO_Birthdate",
+    "homeLanguages": "SO_Language spoken at home",
+    "school": "SO_School"
+  },
+  "": "SO_"
+}

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -19,8 +19,8 @@
     "approveTermsText_link": "servicevillkor",
     "basicInfo": "Basuppgifter",
     "birthDate": "Födelsedatum",
-    "explanationError": "Du har antingen redan godkänt ansökan från din ungdom eller så har ett fel inträffat i vår tjänst.",
     "explanationCheckStatus": "Ungdomar kan kontrollera sin ansökningsstatus genom att logga in på Jässäri. Be honom skicka om bekräftelsemeddelandet om hans medlemskap ännu inte har godkänts.",
+    "explanationError": "Du har antingen redan godkänt ansökan från din ungdom eller så har ett fel inträffat i vår tjänst.",
     "formExplanationText_1": "har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för att godkännas. Om du godkänner ansökan, får",
     "formExplanationText_2": "delta i ungdomsgårdarnas verksamhet och hobbygrupper. Verksamheten leds av utbildade ungdomsledare. Om det finns fel i uppgifterna, be den unga personen att korrigera dem och skicka ett nytt bekräftelsemeddelande till dig.",
     "languagesAtHome": "Hemspråk",
@@ -38,11 +38,11 @@
     "deviceTimeError": {
       "message": "Tro det eller ej, men du kan inte logga in eftersom din enhets klocka går mer än 5 minuter fel. Justera klockan och försök igen."
     },
+    "errorMessage": "Ett fel uppstod. Försök igen",
+    "errorTitle": "Hoppsan!",
     "permRequestDenied": {
       "message": "Du måste godkänna begäran om åtkomst till din Tunnistamo-profil för att kunna använda den här tjänsten. Försök att logga in igen."
-    },
-    "errorTitle": "Hoppsan!",
-    "errorMessage": "Ett fel uppstod. Försök igen"
+    }
   },
   "confirmSendingProfile": {
     "buttonText": "Skicka en ny begäran till vårdnadshavaren",
@@ -54,8 +54,32 @@
   "edit": {
     "pageTitle": "Redigera egen information"
   },
+  "emailApproval": {
+    "content": "Hej {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för godkännande. Medlemskapet är kostnadsfritt. Om du godkänner ansökan, kan {{ youth_profile.profile.first_name }} delta i ungdomsgårdarnas verksamhet och få trevliga förmåner. Om det finns fel i uppgifterna, be den unga att korrigera dem och sedan skicka ett nytt bekräftelsemeddelande till dig. Du kan ge ditt godkännande med Jässäri-tjänsten via denna länk:<br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>",
+    "heading": "{{ youth_profile.profile.first_name }} har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för godkännande."
+  },
+  "emailApproved": {
+    "content": "Välkommen som medlem i Helsingfors stads ungdomstjänster! {{ youth_profile.approver_first_name }} har godkänt ditt edlemskap i Helsingfors stads ungdomstjänster. Ditt digitala medlemskort kan hittas här: <a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a><br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>",
+    "heading": "{{ youth_profile.approver_first_name }} har godkänt ditt edlemskap i Helsingfors stads ungdomstjänster"
+  },
+  "emailRenew": {
+    "content": "Hejsan {{ youth_profile.profile.first_name }}! Ditt medlemskap i ungdomstjänsterna håller på att gå ut. Det är enkelt att förnya medlemskapet här https://jassari.hel.fi/ <br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>",
+    "heading": "{{ youth_profile.profile.first_name }} ditt medlemskap i ungdomstjänsterna håller på att gå ut"
+  },
   "externalLink": {
     "description": "Öppnas i nytt fönster"
+  },
+  "fields": {
+    "city": "en stad",
+    "email": "en e-postadress",
+    "firstName": "ett förnamn",
+    "lastName": "ett efternamn",
+    "phoneNumber": "ett telefonnummer",
+    "photoUsageApproved": "tillstånd för fotografering",
+    "postalCode": "ett postnummer",
+    "schoolClass": "en skolklass",
+    "schoolName": "ett skolnamn",
+    "streetAddress": "en gatuadress"
   },
   "footer": {
     "accessibility": "Tillgänglighetsdokument",
@@ -77,14 +101,14 @@
     "SWEDISH": "Svenska"
   },
   "language": {
-    "fi": "Suomi",
-    "sv": "Svenska",
+    "ar": "العربية",
     "en": "English",
+    "et": "eesti keel",
+    "fi": "Suomi",
     "fr": "français",
     "ru": "Русский язык",
-    "et": "eesti keel",
     "so": "af Soomaali",
-    "ar": "العربية"
+    "sv": "Svenska"
   },
   "loading": "Laddar...",
   "login": {
@@ -93,10 +117,10 @@
     "helpText": "Jässäri är ditt medlemskort till ungdomsgårdarna. Medlemskapet garanterar trevliga aktiviteter: häng på ungdomsgårdarna, delta i hobbygrupper, ansök om projektunderstöd eller producera ett eget evenemang! Verksamheten leds av utbildade ungdomsledare.",
     "helpTextUnderAge": "För att skaffa Jässäri digitalt måste du ha fyllt 13 år. Om du är yngre kan du ladda ner en ansökningsblankett för Jässäri här. Fyll i blanketten tillsammans med din vårdnadshavare och returnera den till ungdomsgården, så får du ett eget medlemskort.",
     "linkForMembersText": "Har du medlemskap? Logga in",
+    "pageTitle": "Ungdomskort",
     "registrationForm": "http://jassari.munstadi.fi/files/2020/07/Jasenkorttikaavake_2020_ruotsi.pdf",
     "registrationFormText": "Ladda ner ansökningsblanketten ",
     "return": "Gå tillbaka",
-    "pageTitle": "Ungdomskort",
     "title": "Skaffa Jässäri!"
   },
   "membershipDetails": {
@@ -112,39 +136,39 @@
   "membershipInformation": {
     "pageTitle": "Medlemskapsinformation",
     "renew": "Förnya medlemskapet",
-    "renewUnderage": "Skicka en förnyelsebegäran till vårdnadshavaren",
     "renewSuccessMessage": "Medlemskapet förnyades framgångsrikt!",
     "renewSuccessMessageMinor": "Förnyelsebegäran skickades!",
     "renewSuccessTitle": "Framgång",
+    "renewUnderage": "Skicka en förnyelsebegäran till vårdnadshavaren",
     "showProfileInformation": "Visa profiluppifter",
-    "title": "Medlemskortnummer {{number}}",
-    "validUntil": "Gäller till {{date}}",
     "status": {
+      "description": {
+        "expired": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande.",
+        "pending": "Din förnyelsebegäran har skickats till {{email}}",
+        "renewable": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande.",
+        "renewing": "Din förnyelsebegäran har skickats till {{email}}"
+      },
       "title": {
         "membershipExpired": "Medlemskapet har löpt ut.",
-        "renewable": "Medlemskapet upphör att gälla den {{date}}.",
         "pending": "Förnyelse av medlemskap väntar på vårdnadshavares godkännande.",
+        "renewable": "Medlemskapet upphör att gälla den {{date}}.",
         "renewing": "Medlemskapet upphör att gälla den {{date}}. Förnyelse väntar på vårdnadshavares godkännande."
-      },
-      "description": {
-        "renewable": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande.",
-        "pending": "Din förnyelsebegäran har skickats till {{email}}",
-        "renewing": "Din förnyelsebegäran har skickats till {{email}}",
-        "expired": "Skicka in ditt medlemskap igen till din vårdnadshavare för godkännande."
       }
-    }
+    },
+    "title": "Medlemskortnummer {{number}}",
+    "validUntil": "Gäller till {{date}}"
   },
   "meta": {
     "description": "Jässäri är ditt medlemskort till ungdomsgårdarna. Medlemskapet garanterar trevliga aktiviteter: häng på ungdomsgårdarna, delta i hobbygrupper, ansök om projektunderstöd eller producera ett eget evenemang! Verksamheten leds av utbildade ungdomsledare."
   },
   "nav": {
+    "helsinki": "Helsingfors",
+    "menu": "Meny",
     "menuButtonLabel": "Profilmeny",
     "profile": "Helsingfors profil",
     "signin": "Logga in",
     "signout": "Logga ut",
-    "menu": "Meny",
-    "skipToContent": "Gå till huvudinnehåll",
-    "helsinki": "Helsingfors"
+    "skipToContent": "Gå till huvudinnehåll"
   },
   "notification": {
     "closeButtonText": "Stäng",
@@ -167,6 +191,9 @@
     "verifying": "Kontrollerar profil..."
   },
   "registration": {
+    "addAddress": "Lägg till en annan adress",
+    "addGuardian": "Lägg till en annan förmyndares uppgifter",
+    "addGuardianText": "Vid behov kan andra vårdnadshavare kontaktas i frågor som rör ditt ungdomsmedlemskap.",
     "addInfo": "Ytterligare information",
     "address": "Gatuadress",
     "ageRestriction": "Endast 8-29 åringar kan skaffa Jässäri.",
@@ -201,16 +228,13 @@
     "postalCode": "Postnummer",
     "processInfoText": "En begäran om dataverifiering skickas till föräldern och efter att ddina uppgifter är granskade och godkända träder ditt medlemskap i kraft.",
     "profileLanguage": "Profilspråk",
+    "remove": "Radera",
     "save": "Spara information",
     "schoolClass": "Skolklass",
     "schoolName": "Skola",
     "sendButton": "Spara och skicka verifieringsförfrågan",
     "title": "Vänligen fyll i din information",
-    "year": "År",
-    "addAddress": "Lägg till en annan adress",
-    "addGuardian": "Lägg till en annan förmyndares uppgifter",
-    "addGuardianText": "Vid behov kan andra vårdnadshavare kontaktas i frågor som rör ditt ungdomsmedlemskap.",
-    "remove": "Radera"
+    "year": "År"
   },
   "registry": {
     "descriptionLink": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Medlemsregister%20f%C3%B6r%20ungdomstj%C3%A4nsterna.pdf"
@@ -239,8 +263,8 @@
   "validation": {
     "email": "Ange en giltig e-postadress",
     "invalidPostalCode": "Fyll i ett giltigt postnummer",
-    "requiredTerms": "Godkänn villkoren",
     "required": "Fyll i {{label}}",
+    "requiredTerms": "Godkänn villkoren",
     "tooLong": "Fyll i {{label}} som är mindre än {{max}} tecken långt",
     "tooShort": "Fyll i {{label}} som är mer än {{min}} tecken långt"
   },
@@ -252,29 +276,5 @@
     "birthdate": "Födelsedatum",
     "homeLanguages": "Ditt hemspråk",
     "school": "Skola"
-  },
-  "emailApproval": {
-    "heading": "{{ youth_profile.profile.first_name }} har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för godkännande.",
-    "content": "Hej {{ youth_profile.approver_first_name }},<br /><br />{{ youth_profile.profile.first_name }} har skickat dig en ansökan om medlemskap i Helsingfors stads ungdomstjänster för godkännande. Medlemskapet är kostnadsfritt. Om du godkänner ansökan, kan {{ youth_profile.profile.first_name }} delta i ungdomsgårdarnas verksamhet och få trevliga förmåner. Om det finns fel i uppgifterna, be den unga att korrigera dem och sedan skicka ett nytt bekräftelsemeddelande till dig. Du kan ge ditt godkännande med Jässäri-tjänsten via denna länk:<br /><br /><a href=\"https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}\">https://jassari.hel.fi/approve/{{ youth_profile.approval_token }}</a><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>"
-  },
-  "emailApproved": {
-    "heading": "{{ youth_profile.approver_first_name }} har godkänt ditt edlemskap i Helsingfors stads ungdomstjänster",
-    "content": "Välkommen som medlem i Helsingfors stads ungdomstjänster! {{ youth_profile.approver_first_name }} har godkänt ditt edlemskap i Helsingfors stads ungdomstjänster. Ditt digitala medlemskort kan hittas här: <a href=\"https://jassari.hel.fi\">https://jassari.hel.fi</a><br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>"
-  },
-  "emailRenew": {
-    "heading": "{{ youth_profile.profile.first_name }} ditt medlemskap i ungdomstjänsterna håller på att gå ut",
-    "content": "Hejsan {{ youth_profile.profile.first_name }}! Ditt medlemskap i ungdomstjänsterna håller på att gå ut. Det är enkelt att förnya medlemskapet här https://jassari.hel.fi/ <br /><br />Mer information om medlemskapet i ungdomstjänsterna och förmånerna finns på adressen <a href=\"http://jassari.munstadi.fi/sv/\">http://jassari.munstadi.fi/sv/<a/><br /><br /> <i>Det här meddelandet skickades automatiskt från våra system. Svara inte på det här meddelandet eftersom svaren inte kommer att behandlas. </i>"
-  },
-  "fields": {
-    "firstName": "ett förnamn",
-    "lastName": "ett efternamn",
-    "streetAddress": "en gatuadress",
-    "postalCode": "ett postnummer",
-    "city": "en stad",
-    "phoneNumber": "ett telefonnummer",
-    "email": "en e-postadress",
-    "schoolName": "ett skolnamn",
-    "schoolClass": "en skolklass",
-    "photoUsageApproved": "tillstånd för fotografering"
   }
 }


### PR DESCRIPTION
## Description

Adds placeholder translations into the translation sheets and pulls them into the service.

The update translations script was changed to ask for the additional langauges.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-490](https://helsinkisolutionoffice.atlassian.net/browse/YM-490)
