### PR TITLE
YM-512 | Reorder GraphQL calls for creating youth membership

### DIFF
--- a/src/domain/youthProfile/hooks/useCreateProfiles.ts
+++ b/src/domain/youthProfile/hooks/useCreateProfiles.ts
@@ -48,11 +48,7 @@ const useCreateProfiles = ({ onError }: Options) => {
     addServiceConnection,
     { loading: addingServiceConnection },
   ] = useMutation<AddServiceConnectionData, AddServiceConnectionVariables>(
-    ADD_SERVICE_CONNECTION,
-    {
-      refetchQueries: ['HasYouthProfile', 'NameQuery'],
-      awaitRefetchQueries: true,
-    }
+    ADD_SERVICE_CONNECTION
   );
 
   const [createMyProfile, { loading: creatingMyProfile }] = useMutation<
@@ -64,7 +60,11 @@ const useCreateProfiles = ({ onError }: Options) => {
     createMyYouthProfile,
     { loading: creatingMyYouthProfile },
   ] = useMutation<CreateMyYouthProfileData, CreateMyYouthProfileVariables>(
-    CREATE_MY_YOUTH_PROFILE
+    CREATE_MY_YOUTH_PROFILE,
+    {
+      refetchQueries: ['HasYouthProfile', 'NameQuery'],
+      awaitRefetchQueries: true,
+    }
   );
 
   const [updateMyYouthProfile, { loading: updatingMyProfile }] = useMutation<
@@ -111,12 +111,12 @@ const useCreateProfiles = ({ onError }: Options) => {
       } else {
         await createMyProfile({ variables: myProfileVariables });
       }
+      await addServiceConnection({ variables: serviceConnectionVariables });
       await createMyYouthProfile({ variables: myYouthProfileVariables });
       await trackEvent({
         category: 'action',
         action: 'Register youth membership',
       });
-      await addServiceConnection({ variables: serviceConnectionVariables });
       history.push('/');
     } catch (e) {
       Sentry.captureException(e);


### PR DESCRIPTION
## Description
Due to open-city-profile deprecating some old behavior, the order of the calls is changed when registering a new member to:

1. Create Helsinki profile
2. Add connection to Youth membership service
3. Create Youth profile

The last call eventually also calls the Helsinki profile in the youth membership backend. The service connection needs to be created into Helsinki profile before the youth membership profile creation call is made.

## Context
[YM-512](https://helsinkisolutionoffice.atlassian.net/browse/YM-512) Change the order in which the service connection to Youth membership is made

## How Has This Been Tested?
I used the latest development branch of open-city-profile, which doesn't have the implicit connection feature/logic anymore, which allowed the old way of creating the youth membership profile before the service connection is created into Helsinki profile. 

I checked that without the changes the youth-membership backend was unable to successfully create the youth profile (which requires querying the Helsinki profile backend). With the changes there's no errors.  
