### PR TITLE
Removed the update and remove addresses fields from the create profile mutation

### DIFF
--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`matches snapshot 1`] = `
           <span
             class="value"
           >
-            01.01.2007
+            01.01.2008
           </span>
         </div>
         <div

--- a/src/domain/youthProfile/helpers/contactInformationUtils.ts
+++ b/src/domain/youthProfile/helpers/contactInformationUtils.ts
@@ -1,0 +1,123 @@
+import { isEqual } from 'lodash';
+
+import {
+  PrefillRegistartion,
+  MembershipDetails,
+  AddressType,
+  EmailType,
+  PhoneType,
+} from '../../../graphql/generatedTypes';
+import getAddressesFromNode from '../../membership/helpers/getAddressesFromNode';
+import { Values as FormValues } from '../form/YouthProfileForm';
+
+export const getPrimaryAddress = (
+  profileType: 'prefill' | 'membership',
+  profile?: PrefillRegistartion | MembershipDetails
+) => {
+  switch (profileType) {
+    case 'membership':
+      return (profile as MembershipDetails).myYouthProfile?.profile
+        ?.primaryAddress;
+    case 'prefill':
+      return (profile as PrefillRegistartion).myProfile?.primaryAddress;
+    default:
+      return { id: '' };
+  }
+};
+
+export const getAddress = (
+  formValues: FormValues,
+  profileType: 'prefill' | 'membership',
+  profile?: PrefillRegistartion | MembershipDetails
+) => {
+  const profileAddresses = [
+    ...getAddressesFromNode(profileType, profile),
+    getPrimaryAddress(profileType, profile),
+  ];
+
+  const addAddresses = formValues.addresses
+    .filter(addresss => !addresss.id)
+    .map(address => ({
+      address: address.address,
+      postalCode: address.postalCode,
+      city: address.city,
+      countryCode: address.countryCode,
+      primary: address.primary,
+      addressType: address.addressType || AddressType.OTHER,
+    }));
+
+  const updateAddresses = formValues.addresses
+    .filter(address => {
+      const profileAddress = profileAddresses.find(
+        value => value?.id === address.id
+      );
+
+      return address.id && !isEqual(address, profileAddress);
+    })
+    .map(address => ({
+      id: address.id,
+      address: address.address,
+      postalCode: address.postalCode,
+      city: address.city,
+      countryCode: address.countryCode,
+      primary: address.primary,
+      addressType: address.addressType || AddressType.OTHER,
+    }));
+
+  const formValueIDs = formValues.addresses.map(address => address.id);
+
+  const removeAddresses = profileAddresses
+    .filter(address => address?.id && !formValueIDs.includes(address.id))
+    .map(address => address?.id || null);
+
+  return {
+    addAddresses,
+    updateAddresses,
+    removeAddresses,
+  };
+};
+
+export const getPhone = (
+  formValues: FormValues,
+  profile?: PrefillRegistartion
+) => {
+  if (profile?.myProfile?.primaryPhone?.id) {
+    return {
+      updatePhones: [
+        {
+          phone: formValues.phone,
+          phoneType: PhoneType.OTHER,
+          primary: true,
+          id: profile?.myProfile?.primaryPhone?.id,
+        },
+      ],
+    };
+  }
+
+  return {
+    addPhones: [
+      {
+        phone: formValues.phone,
+        phoneType: PhoneType.OTHER,
+        primary: true,
+      },
+    ],
+  };
+};
+
+export const getEmail = (
+  formValues: FormValues,
+  profile?: PrefillRegistartion
+) => {
+  return {
+    addEmails: [
+      !profile?.myProfile?.primaryEmail
+        ? {
+            email: formValues.email,
+            primary: true,
+            emailType: EmailType.OTHER,
+          }
+        : null,
+    ],
+  };
+};

--- a/src/domain/youthProfile/helpers/updateProfileMutationVariables.ts
+++ b/src/domain/youthProfile/helpers/updateProfileMutationVariables.ts
@@ -1,6 +1,6 @@
 import { MembershipDetails, PhoneType } from '../../../graphql/generatedTypes';
 import { Values as FormValues } from '../form/YouthProfileForm';
-import { getAddress } from './createProfileMutationVariables';
+import { getAddress } from './contactInformationUtils';
 
 const getEditMutationVariables = (
   formValues: FormValues,

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -3,6 +3,24 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL query operation: YouthProfileApprovedTime
+// ====================================================
+
+export interface YouthProfileApprovedTime_myYouthProfile {
+  readonly __typename: "YouthProfileNode";
+  readonly id: string;
+  readonly approvedTime: any | null;
+}
+
+export interface YouthProfileApprovedTime {
+  readonly myYouthProfile: YouthProfileApprovedTime_myYouthProfile | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: MembershipDetails
 // ====================================================
 
@@ -46,7 +64,7 @@ export interface MembershipDetails_myYouthProfile_profile_primaryEmail {
 
 export interface MembershipDetails_myYouthProfile_profile_primaryPhone {
   readonly __typename: "PhoneNode";
-  readonly phone: string | null;
+  readonly phone: string;
   readonly id: string;
 }
 
@@ -306,7 +324,7 @@ export interface HasYouthProfile {
 // ====================================================
 
 export interface NameQuery_myProfile {
-  readonly __typename: "ProfileWithVerifiedPersonalInformationNode";
+  readonly __typename: "ProfileNode";
   readonly firstName: string;
   readonly lastName: string;
   readonly nickname: string;
@@ -326,7 +344,7 @@ export interface NameQuery {
 
 export interface PrefillRegistartion_myProfile_primaryPhone {
   readonly __typename: "PhoneNode";
-  readonly phone: string | null;
+  readonly phone: string;
   readonly id: string;
 }
 
@@ -368,7 +386,7 @@ export interface PrefillRegistartion_myProfile_primaryEmail {
 }
 
 export interface PrefillRegistartion_myProfile {
-  readonly __typename: "ProfileWithVerifiedPersonalInformationNode";
+  readonly __typename: "ProfileNode";
   readonly firstName: string;
   readonly lastName: string;
   readonly language: Language | null;
@@ -430,7 +448,7 @@ export interface ProfileWithAccessToken_profileWithAccessToken_primaryEmail {
 
 export interface ProfileWithAccessToken_profileWithAccessToken_primaryPhone {
   readonly __typename: "PhoneNode";
-  readonly phone: string | null;
+  readonly phone: string;
   readonly id: string;
 }
 
@@ -604,7 +622,7 @@ export interface MembershipDetailsFragment_profile_primaryEmail {
 
 export interface MembershipDetailsFragment_profile_primaryPhone {
   readonly __typename: "PhoneNode";
-  readonly phone: string | null;
+  readonly phone: string;
   readonly id: string;
 }
 
@@ -796,7 +814,6 @@ export interface ProfileInput {
   readonly addEmails?: ReadonlyArray<(CreateEmailInput | null)> | null;
   readonly addPhones?: ReadonlyArray<(CreatePhoneInput | null)> | null;
   readonly addAddresses?: ReadonlyArray<(CreateAddressInput | null)> | null;
-  readonly subscriptions?: ReadonlyArray<(SubscriptionInputType | null)> | null;
   readonly sensitivedata?: SensitiveDataFields | null;
   readonly updateEmails?: ReadonlyArray<(UpdateEmailInput | null)> | null;
   readonly removeEmails?: ReadonlyArray<(string | null)> | null;
@@ -816,17 +833,12 @@ export interface SensitiveDataFields {
 }
 
 export interface ServiceConnectionInput {
-  readonly service: ServiceInput;
+  readonly service?: ServiceInput | null;
   readonly enabled?: boolean | null;
 }
 
 export interface ServiceInput {
   readonly type?: ServiceType | null;
-}
-
-export interface SubscriptionInputType {
-  readonly subscriptionTypeId: string;
-  readonly enabled: boolean;
 }
 
 export interface UpdateAdditionalContactPersonInput {


### PR DESCRIPTION
YM-515. Production hotfix. Updated the schema by generating the new types with codegen.

Testing instruction:
1. Go to https://jassari.test.kuva.hel.ninja
2. Create a profile (this failed before the fix and it was shown in the network tab and with a visible notification)
3. Update a profile (this uses the same getAddress -functions as the creation, so needs a test also)