### PR TITLE
Fixed the age tests and snapshots

### DIFF
--- a/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
+++ b/src/domain/youthProfile/approve/__test__/__snapshots__/ApproveYouthProfileForm.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`matches snapshot 1`] = `
           <span
             class="value"
           >
-            01.01.2008
+            01.01.2009
           </span>
         </div>
         <div

--- a/src/domain/youthProfile/helpers/__tests__/createProfileMutationVariables.test.ts
+++ b/src/domain/youthProfile/helpers/__tests__/createProfileMutationVariables.test.ts
@@ -1,3 +1,5 @@
+import { format, subYears } from 'date-fns';
+
 import { Values as FormValues } from '../../form/YouthProfileForm';
 import {
   AddressType,
@@ -12,6 +14,7 @@ import {
   getPhone,
 } from '../createProfileMutationVariables';
 import { getCreateYouthProfile } from '../youthProfileGetters';
+import ageConstants from '../../constants/ageConstants';
 
 const additionalContactPersons = [
   {
@@ -146,7 +149,11 @@ describe('getYouthProfile tests', () => {
   });
 
   it('user is younger than ageConstants.PHOTO_PERMISSION_MIN', () => {
-    const formVariables = { ...formValues, birthDate: '2008-01-01' };
+    const birthDate = format(
+      subYears(new Date(), ageConstants.PHOTO_PERMISSION_MIN - 1),
+      'yyyy-MM-dd'
+    );
+    const formVariables = { ...formValues, birthDate };
     const youthVariables = getCreateYouthProfile(formVariables);
     expect(youthVariables.photoUsageApproved).toBeUndefined();
   });


### PR DESCRIPTION
## Description
When yet another year has passed, the age calculation now failed. Changed the calculation to be dynamic.

## Context
Required for tests to pass.